### PR TITLE
feat: Embedder interface + cross-machine sync + no-silent-fallback UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,11 +17,21 @@ Persistent memory CLI for AI coding agents. Notes + sessions with bidirectional 
 - `tests/` — Black-box feature test suite
 
 ## Core Constraints (Inviolable)
-1. **Zero network** — Binary MUST NOT import net/http. Verified: `make verify-no-network`
+1. **Opt-in network** — Default install makes **zero** network calls. Network is only
+   activated when the user explicitly selects a backend that needs it via
+   `claudemem setup`:
+   - TF-IDF (default) → no network ever
+   - Local Ollama → localhost only
+   - Gemini / Voyage / OpenAI → external API calls (explicit user choice)
+   Secrets (API keys) are **always** env-var-only; config.json stores only the env
+   var NAME. Enforced by `IsSecretKey` guard in `pkg/config/wizard.go`.
 2. **CGO_ENABLED=0** — All deps must be pure Go. No C bindings.
-3. **Single binary** — No runtime dependencies, no daemon processes
-4. **Human-readable storage** — Markdown files with YAML frontmatter, always inspectable
-5. **Backward compatible** — Existing notes/sessions must survive upgrades
+3. **Single binary** — No runtime dependencies, no daemon processes required by
+   the tool itself (user may opt into an Ollama daemon via setup).
+4. **Human-readable storage** — Markdown files with YAML frontmatter, always
+   inspectable. SQLite index + vectors are regenerable from markdown.
+5. **Backward compatible** — Existing notes/sessions must survive upgrades.
+   Schema migrations preserve data (see v21→v22 migration in pkg/vectors/store.go).
 
 ## Build & Test
 ```bash
@@ -30,7 +40,6 @@ make test               # Smoke tests (5 cases)
 make e2e-test           # E2E CLI tests (10 cases)
 make feature-test       # Black-box feature tests (82 cases)
 make test-all           # All tests: unit + smoke + E2E + feature
-make verify-no-network  # Verify no net/http in binary
 make install            # Install to ~/.local/bin/
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 LDFLAGS := -s -w -X github.com/zelinewang/claudemem/cmd.Version=$(VERSION)
 BINARY  := claudemem
 
-.PHONY: build install test feature-test e2e-test clean verify-no-network test-all
+.PHONY: build install test feature-test e2e-test clean test-all
 
-# Default build: no network, no sync
+# Build a single static binary (pure Go, no CGO). Network calls are
+# opt-in at runtime via `claudemem setup` — default is zero network.
 build:
 	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
@@ -48,9 +49,6 @@ test-all: build
 	@echo ""
 	@echo "=== Feature Tests ==="
 	@bash tests/feature_test.sh
-
-verify-no-network: build
-	@echo "✓ Network check: net/http allowed for localhost Ollama only (no external URLs)"
 
 clean:
 	rm -f $(BINARY)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Want every session saved automatically? Add this to your `~/.claude/CLAUDE.md`:
 - **Custom sections preserved** — architecture diagrams, performance tables, file lists — nothing silently dropped
 - **Smart dedup** — notes merge by topic; sessions stay separate by conversation (session_id-based)
 - **FTS5 search** — full-text search across all notes and sessions in <10ms
-- **Zero network** — everything local, no cloud, no telemetry
+- **Opt-in network** — default is zero-network (TF-IDF or offline). Cloud embedding backends (Gemini / Voyage / OpenAI) are explicit per-machine choices via `claudemem setup`; API keys come from env vars only, never stored in config
 - **Portable** — export/import as tar.gz, move between machines
 - **200+ tests** — unit, integration, E2E, and black-box feature tests
 
@@ -240,7 +240,7 @@ skills.sh shows "High Risk" / "Critical Risk" badges — this is normal for **an
 | Socket | 1 alert | `install.sh` downloads binary via curl | Standard Go distribution |
 | Snyk | Critical | `modernc.org/sqlite` (C-to-Go transpile) has CVEs | Industry-standard SQLite lib |
 
-**What claudemem actually does**: zero network calls, all data local, parameterized SQL queries, path traversal protection, 200+ tests passing. Full source: ~5,500 lines of Go, fully auditable.
+**What claudemem actually does**: zero network by default (TF-IDF or offline Ollama); cloud embedding backends are opt-in per-machine via `claudemem setup` with API keys from env vars only. Parameterized SQL queries, path traversal protection, 269+ tests passing. Full source: ~8,500 lines of Go, fully auditable.
 
 ## Tell a Friend
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ claudemem session get <id-or-prefix>
 # Search everything
 claudemem search "query" [--type note|session] [--limit N]
 
+# Embedding backend (pick one; no silent fallback)
+claudemem setup                              # interactive wizard: Local / Gemini / Voyage / OpenAI / TF-IDF
+claudemem health                             # I1-I3 parity check (markdown ↔ FTS ↔ vectors, <100ms)
+claudemem health --deep                      # also I4/I5 (orphans, config match)
+claudemem repair                             # fix drift detected by health (interactive)
+
+# Cross-machine sync (markdown-only via git)
+claudemem sync init <remote-url>             # git init ~/.claudemem with remote
+claudemem sync push                          # commit + push notes/sessions
+claudemem sync pull                          # pull + rebuild FTS + embed missing vectors
+claudemem sync status                        # git status + index health
+
 # Utilities
 claudemem stats
 claudemem verify
@@ -80,6 +92,75 @@ claudemem import backup.tar.gz
 ```
 
 Add `--format json` to any command for structured output.
+
+## Setup — Pick Your Search Backend
+
+Semantic search uses an embedding model. Pick it explicitly — claudemem never
+falls back silently to a worse backend behind your back.
+
+```bash
+claudemem setup
+```
+
+The wizard walks through:
+
+| Option | Where it runs | Cost | Chinese | When to pick |
+|---|---|---|---|---|
+| **Local — Ollama** | Your machine | Free | qwen3 ✅ / nomic weaker | Daily use, offline, airgapped |
+| **Cloud — Gemini** | Google | $0.15/M tokens (≈$0.50/mo for 3K notes) | ✅ 100+ langs | Best quality, you already have a key |
+| **Cloud — Voyage** | Voyage AI | $0.02/M, 200M free tokens | ✅ | Budget pick, effectively free |
+| **Cloud — OpenAI** | OpenAI | $0.02/M (3-small) | ⚠️ English-heavy | You already pay OpenAI for other things |
+| **TF-IDF** | Your machine | Free | OK | No daemon, no keys, keyword-ish similarity |
+
+API keys are always read from environment variables (`GEMINI_API_KEY`,
+`VOYAGE_API_KEY`, `OPENAI_API_KEY`) — claudemem refuses to store them in
+`config.json`. Only the env var **name** is recorded, so configs are safe
+to commit + sync across machines.
+
+Manual equivalent (for scripts):
+
+```bash
+claudemem config set embedding.backend gemini
+claudemem config set embedding.model gemini-embedding-001
+claudemem config set embedding.dimensions 768
+claudemem config set embedding.api_key_env GEMINI_API_KEY
+claudemem reindex --vectors
+```
+
+### When the backend is down
+
+claudemem never degrades silently. If the configured backend is unreachable:
+
+- **Non-interactive shells / CI**: error with recovery instructions + exit 1.
+- **Interactive terminals**: prompt offering retry / FTS-only-this-query / run setup.
+
+Use `claudemem search "..." --fts-only` to skip semantic for one query
+when you know the backend is down.
+
+## Cross-Machine Memory
+
+Memory can follow you between machines (web_dev ↔ MacBook, etc.) via a
+private git repo.
+
+```bash
+# once, per user
+claudemem sync init git@github.com:YOU/claudemem-memory.git
+
+# after work
+claudemem sync push
+
+# on another machine, first time
+git clone git@github.com:YOU/claudemem-memory.git ~/.claudemem
+claudemem sync pull
+```
+
+Only markdown travels over the wire — SQLite index and config stay
+per-machine. Each machine embeds under ITS configured backend, so
+a cloud-Gemini laptop and a local-Ollama workstation can share the
+same corpus with zero backend coupling.
+
+See [docs/HOOK_INTEGRATION.md](docs/HOOK_INTEGRATION.md) for Claude Code
+hook integration (auto-pull on SessionStart, auto-push on SessionEnd).
 
 ## Recommended: Auto Wrap-Up
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,24 @@ If you discover a security vulnerability, please report it via [GitHub Issues](h
 
 ## Security Design
 
-- **Zero network**: The default binary makes no network calls. No telemetry, no analytics, no cloud.
-- **Local-only storage**: All data stays at `~/.claudemem/` with `0600`/`0700` permissions.
-- **Input validation**: Path traversal protection, SQL parameterized queries, input length limits.
-- **Dependency scanning**: `govulncheck` reports 0 vulnerabilities in the current release.
-- **Open source**: ~4,800 lines of Go, fully auditable.
+- **Opt-in network**: Default install makes no network calls. Network activates only
+  when the user explicitly selects a backend via `claudemem setup`:
+  - TF-IDF (default) or offline — no network ever
+  - Local Ollama — localhost only
+  - Gemini / Voyage / OpenAI — external API calls (user must opt in per machine)
+  No telemetry, no analytics.
+- **Secrets never on disk**: API keys for cloud backends are read from environment
+  variables only (`GEMINI_API_KEY`, `VOYAGE_API_KEY`, `OPENAI_API_KEY`). The
+  `IsSecretKey` guard in `pkg/config/wizard.go` refuses `claudemem config set`
+  attempts on secret-looking keys; `config.json` stores only the env var NAME.
+- **Local-only storage**: Notes, sessions, and SQLite index stay at `~/.claudemem/`
+  with `0600`/`0700` permissions. Optional cross-machine sync (`claudemem sync`)
+  ships only markdown via a user-provided private git remote.
+- **Input validation**: Path traversal protection, SQL parameterized queries,
+  input length limits.
+- **Dependency scanning**: `govulncheck` reports no code-level vulnerabilities in
+  project packages. Stdlib CVEs follow the Go toolchain version in use.
+- **Open source**: ~8,500 lines of Go, fully auditable.
 
 ## Supported Versions
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -25,6 +25,20 @@ var configSetCmd = &cobra.Command{
 		key := args[0]
 		value := args[1]
 
+		// Secret guard: claudemem never stores API keys / tokens / passwords
+		// in config.json. Those live in env vars; config stores only the
+		// NAME of the env var (e.g. embedding.api_key_env=GEMINI_API_KEY).
+		// Rejecting here catches the "copy-pasted curl command" footgun.
+		if config.IsSecretKey(key) {
+			return fmt.Errorf(
+				"refusing to store secret-looking key %q in config.json\n"+
+					"  claudemem keeps secrets in env vars only. Set your key there:\n"+
+					"    export GEMINI_API_KEY=...\n"+
+					"  And record the env var NAME (not the value) via:\n"+
+					"    claudemem config set embedding.api_key_env GEMINI_API_KEY",
+				key)
+		}
+
 		cfg, err := loadConfig()
 		if err != nil {
 			return err

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -10,10 +10,9 @@ import (
 	"github.com/zelinewang/claudemem/pkg/vectors"
 )
 
-var (
-	healthQuick bool
-	healthDeep  bool
-)
+// healthDeep is the only runtime flag — "--quick" is the default and
+// doesn't need a separate bool since `health` without flags IS quick.
+var healthDeep bool
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -45,7 +44,6 @@ Drift output:
 }
 
 func runHealth(cmd *cobra.Command, args []string) error {
-	// --quick is the default; --deep overrides
 	isDeep := healthDeep
 
 	fileStore, err := getFileStore()
@@ -127,7 +125,9 @@ func printHealthReport(r *vectors.HealthReport, fs *storage.FileStore) {
 }
 
 func init() {
-	healthCmd.Flags().BoolVar(&healthQuick, "quick", false, "Quick mode (default; <100ms SessionStart-safe)")
+	// --quick is the default; we keep it as a no-op flag for docs/explicit
+	// scripts that want to signal intent. --deep adds I4/I5 invariants.
+	healthCmd.Flags().Bool("quick", false, "Quick mode (default; <100ms SessionStart-safe)")
 	healthCmd.Flags().BoolVar(&healthDeep, "deep", false, "Deep mode: also check for orphans + config match (I4/I5)")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/config"
 	"github.com/zelinewang/claudemem/pkg/storage"
 	"github.com/zelinewang/claudemem/pkg/vectors"
 )
@@ -53,8 +54,15 @@ func runHealth(cmd *cobra.Command, args []string) error {
 	}
 	defer fileStore.Close()
 
-	// Try to initialize vector store so we know the active backend for I3/I5
-	_ = fileStore.InitVectorStore()
+	// Only activate vector-based invariants (I3 for active backend, I5 for
+	// config match) when the user has explicitly opted in to semantic
+	// search. Otherwise existing installs that never enabled it would see
+	// I3/I5 drift for vectors they never asked for. Matches the precedent
+	// set in cmd/reindex.go and cmd/search.go.
+	cfg, _ := config.Load(getStoreDir())
+	if cfg != nil && cfg.GetBool("features.semantic_search") {
+		_ = fileStore.InitVectorStore()
+	}
 
 	in := vectors.HealthInputs{
 		DB:          fileStore.DB(),

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/storage"
+	"github.com/zelinewang/claudemem/pkg/vectors"
+)
+
+var (
+	healthQuick bool
+	healthDeep  bool
+)
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Report FTS + vector index drift (read-only)",
+	Long: `Run a parity check across markdown files, the SQLite entries+FTS tables,
+and the per-(backend,model) vector rows. Reports drift without making
+changes — use 'claudemem repair' to fix.
+
+Invariants (quick mode, <100ms, runs on SessionStart):
+  I1  Every markdown file has a row in entries
+  I2  Every entry has a row in memory_fts
+  I3  Every entry has a vector row for the CURRENTLY CONFIGURED (backend, model)
+
+Deep mode (--deep, slower) additionally validates:
+  I4  No orphan FTS / vector rows (parent entry deleted)
+  I5  vector_meta.index_backend matches the active embedder
+
+Typical output:
+  $ claudemem health
+  ✓ healthy (1086 notes · 1086 entries · 1086 FTS · 1086 vectors for ollama:qwen3-embedding:4b)
+
+Drift output:
+  $ claudemem health
+  ⚠ drift detected
+     I3: active backend gemini:gemini-embedding-001 has 0 vectors but 1086 entries...
+     Run 'claudemem repair' to backfill.
+  Exit 1`,
+	RunE: runHealth,
+}
+
+func runHealth(cmd *cobra.Command, args []string) error {
+	// --quick is the default; --deep overrides
+	isDeep := healthDeep
+
+	fileStore, err := getFileStore()
+	if err != nil {
+		return err
+	}
+	defer fileStore.Close()
+
+	// Try to initialize vector store so we know the active backend for I3/I5
+	_ = fileStore.InitVectorStore()
+
+	in := vectors.HealthInputs{
+		DB:          fileStore.DB(),
+		NotesDir:    fileStore.NotesDir(),
+		SessionsDir: fileStore.SessionsDir(),
+	}
+	if fileStore.HasVectorStore() {
+		in.Embedder = fileStore.VectorStoreEmbedder()
+	}
+
+	var report *vectors.HealthReport
+	if isDeep {
+		report, err = vectors.CheckHealthDeep(in)
+	} else {
+		report, err = vectors.CheckHealth(in)
+	}
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+
+	printHealthReport(report, fileStore)
+	if !report.Healthy() {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func printHealthReport(r *vectors.HealthReport, fs *storage.FileStore) {
+	if outputFormat == "json" {
+		_ = OutputJSON(r)
+		return
+	}
+
+	if r.Healthy() {
+		// Terse one-liner so SessionStart output stays compact
+		vectorLine := "no embedder configured"
+		if r.ActiveBackend != "" {
+			vectorLine = fmt.Sprintf("%d vectors for %s:%s",
+				r.VectorTotals[r.ActiveBackend+":"+r.ActiveModel],
+				r.ActiveBackend, r.ActiveModel)
+		}
+		fmt.Printf("✓ healthy (%d notes · %d entries · %d FTS · %s)\n",
+			r.MarkdownFiles, r.EntriesTotal, r.FTSTotal, vectorLine)
+		return
+	}
+
+	fmt.Fprintln(os.Stderr, "⚠ drift detected")
+	for _, issue := range r.Issues {
+		fmt.Fprintf(os.Stderr, "   %s\n", issue)
+	}
+	// Show the per-backend vector breakdown so user sees cross-machine state
+	if len(r.VectorTotals) > 0 {
+		fmt.Fprintln(os.Stderr, "\nVectors present:")
+		for bm, n := range r.VectorTotals {
+			marker := " "
+			if bm == r.ActiveBackend+":"+r.ActiveModel {
+				marker = "*" // active
+			}
+			fmt.Fprintf(os.Stderr, "  %s %s: %d\n", marker, bm, n)
+		}
+	}
+}
+
+func init() {
+	healthCmd.Flags().BoolVar(&healthQuick, "quick", false, "Quick mode (default; <100ms SessionStart-safe)")
+	healthCmd.Flags().BoolVar(&healthDeep, "deep", false, "Deep mode: also check for orphans + config match (I4/I5)")
+	rootCmd.AddCommand(healthCmd)
+}

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -141,29 +141,10 @@ var verifyCmd = &cobra.Command{
 	},
 }
 
-var repairCmd = &cobra.Command{
-	Use:   "repair",
-	Short: "Repair data integrity issues",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		store, err := getSessionStore()
-		if err != nil {
-			return err
-		}
-		defer store.Close()
-
-		removed, err := store.RepairIntegrity()
-		if err != nil {
-			return fmt.Errorf("repair failed: %w", err)
-		}
-
-		if removed == 0 {
-			OutputText("✓ No issues found — data is healthy!")
-		} else {
-			OutputText("✓ Repaired: removed %d orphaned entries", removed)
-		}
-		return nil
-	},
-}
+// Legacy repairCmd replaced by cmd/repair.go (which also does orphan
+// cleanup plus FTS + vector reindex). Kept as a package-level stub here
+// only because migrate.go's init() still references repairCmd; the real
+// one is in repair.go.
 
 func init() {
 	migrateBraindumpCmd.Flags().String("source", "", "braindump directory (default: ~/.braindump/)")
@@ -174,5 +155,5 @@ func init() {
 
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(verifyCmd)
-	rootCmd.AddCommand(repairCmd)
+	// repairCmd is now registered in cmd/repair.go (richer: handles FTS+vector drift too)
 }

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/config"
 	"github.com/zelinewang/claudemem/pkg/vectors"
 )
 
@@ -35,7 +36,15 @@ func runRepair(cmd *cobra.Command, args []string) error {
 	}
 	defer fileStore.Close()
 
-	_ = fileStore.InitVectorStore()
+	// Same gate as cmd/health.go: only activate vector-based invariants
+	// when the user has opted into semantic search. Otherwise health +
+	// repair would disagree for the same state — health passes (vectors
+	// skipped) while repair would offer to rebuild TF-IDF vectors the
+	// user never asked for. Keeps both commands consistent.
+	cfg, _ := config.Load(getStoreDir())
+	if cfg != nil && cfg.GetBool("features.semantic_search") {
+		_ = fileStore.InitVectorStore()
+	}
 
 	in := vectors.HealthInputs{
 		DB:          fileStore.DB(),

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/vectors"
+)
+
+var (
+	repairYes bool // auto-accept all fixes (for CI / scripting)
+)
+
+var repairCmd = &cobra.Command{
+	Use:   "repair",
+	Short: "Fix drift detected by `claudemem health`",
+	Long: `Run health checks, then offer to repair any detected drift:
+  - FTS5 out of sync → run reindex --fts
+  - Vectors missing for active backend → run reindex --vectors
+  - Orphan rows → delete
+
+Interactive by default. Use --yes to accept all fixes non-interactively
+(safe in CI where healthy state is expected but drift from e.g.
+SIGKILL during reindex needs automatic recovery).`,
+	RunE: runRepair,
+}
+
+func runRepair(cmd *cobra.Command, args []string) error {
+	fileStore, err := getFileStore()
+	if err != nil {
+		return err
+	}
+	defer fileStore.Close()
+
+	_ = fileStore.InitVectorStore()
+
+	in := vectors.HealthInputs{
+		DB:          fileStore.DB(),
+		NotesDir:    fileStore.NotesDir(),
+		SessionsDir: fileStore.SessionsDir(),
+	}
+	if fileStore.HasVectorStore() {
+		in.Embedder = fileStore.VectorStoreEmbedder()
+	}
+	report, err := vectors.CheckHealthDeep(in)
+	if err != nil {
+		return err
+	}
+	if report.Healthy() {
+		OutputText("✓ healthy, nothing to repair")
+		return nil
+	}
+
+	fmt.Fprintln(os.Stderr, "⚠ drift detected:")
+	for _, issue := range report.Issues {
+		fmt.Fprintf(os.Stderr, "   %s\n", issue)
+	}
+	fmt.Fprintln(os.Stderr, "")
+
+	reader := bufio.NewReader(os.Stdin)
+	repairs := 0
+
+	// Fix 1: FTS drift → reindex FTS
+	if !report.I1MarkdownMatchesEntries || !report.I2EntriesMatchesFTS {
+		if confirmRepair(reader, "Rebuild FTS5 index from markdown?") {
+			count, err := fileStore.Reindex()
+			if err != nil {
+				return fmt.Errorf("FTS reindex: %w", err)
+			}
+			OutputText("  ✓ FTS index rebuilt (%d entries)", count)
+			repairs++
+		}
+	}
+
+	// Fix 2: vectors missing for active backend → reindex vectors
+	if !report.I3VectorsMatchActiveBackend && fileStore.HasVectorStore() {
+		prompt := fmt.Sprintf("Rebuild vector index for %s:%s?",
+			report.ActiveBackend, report.ActiveModel)
+		if confirmRepair(reader, prompt) {
+			count, err := fileStore.ReindexVectors()
+			if err != nil {
+				return fmt.Errorf("vector reindex: %w", err)
+			}
+			OutputText("  ✓ Vector index rebuilt (%d documents, backend: %s)",
+				count, fileStore.VectorBackend())
+			repairs++
+		}
+	}
+
+	// Fix 3: orphan rows → delete
+	if report.DidDeepCheck && !report.I4NoOrphanRows {
+		if confirmRepair(reader, "Delete orphan FTS / vector rows?") {
+			var removed int
+			result, err := fileStore.DB().Exec(`DELETE FROM memory_fts WHERE id NOT IN (SELECT id FROM entries)`)
+			if err == nil {
+				if n, _ := result.RowsAffected(); n > 0 {
+					removed += int(n)
+				}
+			}
+			result, err = fileStore.DB().Exec(`DELETE FROM vectors WHERE doc_id NOT IN (SELECT id FROM entries)`)
+			if err == nil {
+				if n, _ := result.RowsAffected(); n > 0 {
+					removed += int(n)
+				}
+			}
+			OutputText("  ✓ Removed %d orphan rows", removed)
+			repairs++
+		}
+	}
+
+	if repairs == 0 {
+		OutputText("No repairs performed.")
+		return nil
+	}
+	OutputText("\nRe-running health check...")
+	report2, err := vectors.CheckHealthDeep(in)
+	if err != nil {
+		return err
+	}
+	if report2.Healthy() {
+		OutputText("✓ healthy now")
+	} else {
+		OutputText("⚠ some drift remains, see `claudemem health --deep`")
+	}
+	return nil
+}
+
+func confirmRepair(reader *bufio.Reader, prompt string) bool {
+	if repairYes {
+		fmt.Fprintf(os.Stderr, "%s [auto-yes]\n", prompt)
+		return true
+	}
+	fmt.Fprintf(os.Stderr, "%s [Y/n] ", prompt)
+	line, _ := reader.ReadString('\n')
+	return strings.ToLower(strings.TrimSpace(line)) != "n"
+}
+
+func init() {
+	repairCmd.Flags().BoolVar(&repairYes, "yes", false, "Accept all fixes non-interactively")
+	rootCmd.AddCommand(repairCmd)
+}

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -90,21 +90,26 @@ func runRepair(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Fix 3: orphan rows → delete
+	// Fix 3: orphan rows → delete.
+	// DESTRUCTIVE operation — errors must surface to the user. Previous
+	// version silently swallowed Exec errors into a "Removed 0" message,
+	// which violates the "no silent fallback" rule for the repair path.
 	if report.DidDeepCheck && !report.I4NoOrphanRows {
 		if confirmRepair(reader, "Delete orphan FTS / vector rows?") {
 			var removed int
-			result, err := fileStore.DB().Exec(`DELETE FROM memory_fts WHERE id NOT IN (SELECT id FROM entries)`)
-			if err == nil {
-				if n, _ := result.RowsAffected(); n > 0 {
-					removed += int(n)
-				}
+			ftsResult, err := fileStore.DB().Exec(`DELETE FROM memory_fts WHERE id NOT IN (SELECT id FROM entries)`)
+			if err != nil {
+				return fmt.Errorf("delete orphan FTS rows: %w", err)
 			}
-			result, err = fileStore.DB().Exec(`DELETE FROM vectors WHERE doc_id NOT IN (SELECT id FROM entries)`)
-			if err == nil {
-				if n, _ := result.RowsAffected(); n > 0 {
-					removed += int(n)
-				}
+			if n, _ := ftsResult.RowsAffected(); n > 0 {
+				removed += int(n)
+			}
+			vecResult, err := fileStore.DB().Exec(`DELETE FROM vectors WHERE doc_id NOT IN (SELECT id FROM entries)`)
+			if err != nil {
+				return fmt.Errorf("delete orphan vector rows: %w", err)
+			}
+			if n, _ := vecResult.RowsAffected(); n > 0 {
+				removed += int(n)
 			}
 			OutputText("  ✓ Removed %d orphan rows", removed)
 			repairs++

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -1,24 +1,29 @@
 package cmd
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/zelinewang/claudemem/pkg/config"
 	"github.com/zelinewang/claudemem/pkg/storage"
+	"github.com/zelinewang/claudemem/pkg/vectors"
 )
 
 var (
-	searchType     string
-	searchLimit    int
-	searchCompact  bool
+	searchType           string
+	searchLimit          int
+	searchCompact        bool
 	searchFilterCategory string
 	searchFilterTags     string
-	searchAfter    string
-	searchBefore   string
-	searchSort     string
-	searchSemantic bool
+	searchAfter          string
+	searchBefore         string
+	searchSort           string
+	searchSemantic       bool
+	searchFTSOnly        bool // P4: explicit opt-in to skip semantic search for this query
 )
 
 var searchCmd = &cobra.Command{
@@ -57,10 +62,31 @@ Examples:
 		if searchSemantic && !useHybrid {
 			return fmt.Errorf("semantic search not enabled; run: claudemem config set features.semantic_search true && claudemem reindex --vectors")
 		}
+		// --fts-only is an explicit per-query opt-out. Honored before init
+		// so we don't even try to reach the configured backend.
+		if searchFTSOnly {
+			useHybrid = false
+		}
 		if useHybrid {
 			if err := fileStore.InitVectorStore(); err != nil {
-				// Graceful: fall back to FTS5 if vector init fails
-				useHybrid = false
+				// P4 "no silent fallback": surface the failure to the user.
+				// Fail loud in non-TTY; offer interactive recovery in TTY.
+				choice, cerr := handleBackendFailure(err, useHybrid)
+				if cerr != nil {
+					return cerr
+				}
+				switch choice {
+				case recoveryRetry:
+					if err2 := fileStore.InitVectorStore(); err2 != nil {
+						return fmt.Errorf("retry failed: %w", err2)
+					}
+				case recoveryFTSOnly:
+					useHybrid = false
+				case recoverySetup:
+					return fmt.Errorf("run `claudemem setup` to reconfigure, then retry")
+				case recoveryExit:
+					return fmt.Errorf("aborted")
+				}
 			}
 		}
 
@@ -89,6 +115,20 @@ Examples:
 		var results []storage.SearchResult
 		if useHybrid && fileStore.HasVectorStore() {
 			results, err = fileStore.HybridSearch(query, opts)
+			// HybridSearch may fail at embed time (backend went down between
+			// init and query). Surface as a recovery prompt. If the user
+			// accepts --fts-only, retry with keyword search; otherwise bail.
+			if err != nil && vectors.IsBackendUnavailable(err) {
+				choice, cerr := handleBackendFailure(err, true)
+				if cerr != nil {
+					return cerr
+				}
+				if choice == recoveryFTSOnly {
+					results, err = fileStore.SearchWithOpts(opts)
+				} else {
+					return fmt.Errorf("search aborted: %w", err)
+				}
+			}
 		} else {
 			results, err = fileStore.SearchWithOpts(opts)
 		}
@@ -212,5 +252,88 @@ func init() {
 	searchCmd.Flags().StringVar(&searchBefore, "before", "", "Filter entries before date (YYYY-MM-DD)")
 	searchCmd.Flags().StringVar(&searchSort, "sort", "relevance", "Sort by: relevance, date")
 	searchCmd.Flags().BoolVar(&searchSemantic, "semantic", false, "Use semantic search (TF-IDF vectors, requires features.semantic_search=true)")
+	searchCmd.Flags().BoolVar(&searchFTSOnly, "fts-only", false, "Skip semantic search for this query (FTS5 keyword only). Useful when the embedding backend is down and you want to search anyway.")
 	rootCmd.AddCommand(searchCmd)
+}
+
+// --- P4: fail-loud + interactive recovery ---
+
+type recoveryChoice int
+
+const (
+	recoveryFail     recoveryChoice = iota // default: error out
+	recoveryRetry                          // user asked to retry the backend call
+	recoveryFTSOnly                        // fall back to FTS5 just for this query
+	recoverySetup                          // user wants to run `claudemem setup`
+	recoveryExit                           // user cancelled
+)
+
+// handleBackendFailure produces either a recovery action (TTY interactive)
+// or a verbose error-exit (non-TTY). The semantics match claudemem's
+// "no silent fallback" rule: the user ALWAYS knows the backend failed
+// and what their options are.
+func handleBackendFailure(err error, wasHybridRequested bool) (recoveryChoice, error) {
+	// Unwrap to the ErrBackendUnavailable if there is one
+	var ebu *vectors.ErrBackendUnavailable
+	if errors.As(err, &ebu) {
+		return handleSpecificBackendFailure(ebu, wasHybridRequested)
+	}
+	// Generic vector-store init failure (e.g., bad config) — treat similarly
+	return handleGenericEmbeddingFailure(err)
+}
+
+func handleSpecificBackendFailure(ebu *vectors.ErrBackendUnavailable, wasHybridRequested bool) (recoveryChoice, error) {
+	if !isInteractive() {
+		// Non-TTY: emit the full error with recovery options, exit 1.
+		fmt.Fprintf(os.Stderr, "Error: embedding backend %q unreachable: %v\n", ebu.Backend, ebu.Cause)
+		fmt.Fprintf(os.Stderr, "\n  Recovery options:\n")
+		fmt.Fprintf(os.Stderr, "    - %s\n", ebu.Hint)
+		fmt.Fprintf(os.Stderr, "    - Re-run this search with --fts-only to use keyword search this one time\n")
+		fmt.Fprintf(os.Stderr, "    - Run `claudemem setup` to switch backend\n")
+		return recoveryFail, fmt.Errorf("%w", ebu)
+	}
+
+	// TTY: interactive prompt
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintf(os.Stderr, "⚠ Embedding backend %q unreachable: %v\n", ebu.Backend, ebu.Cause)
+	fmt.Fprintf(os.Stderr, "  Hint: %s\n", ebu.Hint)
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "What do you want to do?")
+	fmt.Fprintln(os.Stderr, "  1) Retry — I just fixed it")
+	fmt.Fprintln(os.Stderr, "  2) Search FTS-only for this query (no semantic; keyword match)")
+	fmt.Fprintln(os.Stderr, "  3) Run `claudemem setup` to switch backend (exits; re-run your command after)")
+	fmt.Fprintln(os.Stderr, "  4) Exit")
+	fmt.Fprint(os.Stderr, "> ")
+
+	reader := bufio.NewReader(os.Stdin)
+	line, _ := reader.ReadString('\n')
+	switch strings.TrimSpace(line) {
+	case "1":
+		return recoveryRetry, nil
+	case "2":
+		return recoveryFTSOnly, nil
+	case "3":
+		return recoverySetup, nil
+	case "4", "":
+		return recoveryExit, nil
+	default:
+		return recoveryExit, fmt.Errorf("unrecognized choice %q", strings.TrimSpace(line))
+	}
+}
+
+func handleGenericEmbeddingFailure(err error) (recoveryChoice, error) {
+	// Config-shaped failure — tell user to run setup regardless of TTY.
+	fmt.Fprintf(os.Stderr, "Error: vector store init failed: %v\n", err)
+	fmt.Fprintln(os.Stderr, "  Try: claudemem setup")
+	return recoveryFail, err
+}
+
+// isInteractive reports whether stdin is connected to a TTY. Used to
+// branch between "ask the user" and "fail loud with recovery message."
+func isInteractive() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/config"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Interactive setup: pick an embedding backend and verify it works",
+	Long: `Walk through choosing an embedding backend (local Ollama or cloud Gemini),
+verify it is reachable, and (optionally) rebuild the vector index.
+
+claudemem never stores API keys in config files. For cloud backends the
+wizard reads the key from the appropriate environment variable (e.g.
+GEMINI_API_KEY) and records only the env-var NAME in config.json — so
+secrets are always at the OS/shell layer, safe for git sync.
+
+Equivalent manual path (for scripts / CI):
+  claudemem config set embedding.backend gemini
+  claudemem config set embedding.model gemini-embedding-001
+  claudemem config set embedding.dimensions 768
+  claudemem config set embedding.api_key_env GEMINI_API_KEY
+  claudemem reindex --vectors
+`,
+	RunE: runSetup,
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	result, err := config.RunSetupWizard(config.WizardOptions{
+		In:       os.Stdin,
+		Out:      os.Stdout,
+		StoreDir: getStoreDir(),
+	})
+	if err != nil {
+		return fmt.Errorf("setup aborted: %w", err)
+	}
+
+	if err := config.ApplyBackendToConfig(getStoreDir(), result); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	OutputText("Saved embedding.backend=%s, embedding.model=%s to config.json",
+		result.Config.Backend, result.Config.Model)
+
+	if !result.RunReindex {
+		OutputText("Run `claudemem reindex --vectors` when ready to rebuild the index.")
+		return nil
+	}
+
+	// Trigger the existing reindex path. This uses the newly-written config
+	// so the active backend is exactly what the user just picked.
+	store, err := getFileStore()
+	if err != nil {
+		return err
+	}
+	defer store.Close()
+
+	if err := store.InitVectorStore(); err != nil {
+		return fmt.Errorf("init vector store: %w", err)
+	}
+	backend := store.VectorBackend()
+	count, err := store.ReindexVectors()
+	if err != nil {
+		return fmt.Errorf("vector reindex failed: %w", err)
+	}
+	OutputText("Vector index rebuilt: %d documents indexed (backend: %s)", count, backend)
+	return nil
+}
+
+func init() {
+	rootCmd.AddCommand(setupCmd)
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/sync"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Cross-machine memory sync via git (markdown only)",
+	Long: `Sync notes + sessions across machines via a private git repo.
+
+Only markdown files travel over the wire — SQLite index and config.json
+stay per-machine. Each machine rebuilds its own FTS and embeds missing
+vectors under its own configured backend on pull. Two machines can
+run different embedding backends against the same corpus.
+
+Typical flow:
+  claudemem sync init git@github.com:YOU/claudemem-memory.git  # once
+  claudemem sync push                                           # after work
+  # on another machine:
+  claudemem sync pull                                           # receive + reindex
+
+Auto-sync (opt-in, per-machine) via:
+  touch ~/.claudemem/.sync_auto_pull   # auto-pull on SessionStart
+  touch ~/.claudemem/.sync_auto_push   # auto-push on SessionEnd
+See docs/HOOK_INTEGRATION.md for the hook additions.`,
+}
+
+var syncInitCmd = &cobra.Command{
+	Use:   "init <remote-url>",
+	Short: "Initialize git repo at ~/.claudemem and set remote",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		g := sync.NewGitSync(getStoreDir())
+		remote := ""
+		if len(args) == 1 {
+			remote = args[0]
+		}
+		if err := g.Init(remote); err != nil {
+			return err
+		}
+		OutputText("✓ Initialized %s as git repo", getStoreDir())
+		if remote != "" {
+			OutputText("  Remote: %s", remote)
+		} else {
+			OutputText("  No remote set; add later with: cd %s && git remote add origin <url>", getStoreDir())
+		}
+		OutputText("\nNext:")
+		OutputText("  claudemem sync push    # commit + push notes/sessions to remote")
+		OutputText("  claudemem sync pull    # (on another machine) receive updates")
+		return nil
+	},
+}
+
+var syncPushCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Commit new/changed markdown and push to remote",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		g := sync.NewGitSync(getStoreDir())
+		msg, _ := cmd.Flags().GetString("message")
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		if err := g.Push(msg); err != nil {
+			if !quiet {
+				return err
+			}
+			// Quiet mode for hook invocations: log to stderr, exit 0
+			fmt.Fprintf(os.Stderr, "claudemem sync push (quiet): %v\n", err)
+			return nil
+		}
+		if !quiet {
+			OutputText("✓ pushed memory to %s", g.RemoteURL())
+		}
+		return nil
+	},
+}
+
+var syncPullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Pull markdown from remote; rebuild local FTS + embed missing vectors",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		quiet, _ := cmd.Flags().GetBool("quiet")
+		g := sync.NewGitSync(getStoreDir())
+		if err := g.Pull(); err != nil {
+			if !quiet {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "claudemem sync pull (quiet): %v\n", err)
+			return nil
+		}
+
+		// Reconcile: rebuild FTS from markdown (cheap), then embed any docs
+		// missing a vector for the active backend.
+		store, err := getFileStore()
+		if err != nil {
+			return err
+		}
+		defer store.Close()
+
+		ftsCount, err := store.Reindex()
+		if err != nil {
+			return fmt.Errorf("FTS rebuild post-pull: %w", err)
+		}
+
+		// Only touch vectors if semantic search is enabled
+		vectorsAdded := 0
+		_ = store.InitVectorStore()
+		if store.HasVectorStore() {
+			// Full reindex is simpler than diff-based partial embed for v1;
+			// RebuildIndex already scopes the wipe to the active
+			// (backend, model) so cross-machine rows are preserved.
+			n, err := store.ReindexVectors()
+			if err != nil {
+				return fmt.Errorf("vector reindex post-pull: %w", err)
+			}
+			vectorsAdded = n
+		}
+
+		if !quiet {
+			OutputText("✓ pulled memory; reconciled %d FTS entries + %d vectors (backend: %s)",
+				ftsCount, vectorsAdded, store.VectorBackend())
+		}
+		return nil
+	},
+}
+
+var syncStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show git status + health of the local memory store",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		g := sync.NewGitSync(getStoreDir())
+		if !g.IsInitialized() {
+			OutputText("not initialized — run `claudemem sync init <remote-url>` to start")
+			return nil
+		}
+		out, err := g.Status()
+		if err != nil {
+			return err
+		}
+		remote := g.RemoteURL()
+		if remote == "" {
+			remote = "(none)"
+		}
+		OutputText("Remote:  %s", remote)
+		OutputText("Storage: %s", getStoreDir())
+		if out == "" {
+			OutputText("Status:  clean (no uncommitted changes)")
+		} else {
+			OutputText("Status:\n%s", out)
+		}
+		return nil
+	},
+}
+
+func init() {
+	syncPushCmd.Flags().StringP("message", "m", "", "commit message (default: 'memory: sync from <hostname>')")
+	syncPushCmd.Flags().Bool("quiet", false, "suppress output except errors (for hook invocations)")
+	syncPullCmd.Flags().Bool("quiet", false, "suppress output except errors (for hook invocations)")
+
+	syncCmd.AddCommand(syncInitCmd)
+	syncCmd.AddCommand(syncPushCmd)
+	syncCmd.AddCommand(syncPullCmd)
+	syncCmd.AddCommand(syncStatusCmd)
+	rootCmd.AddCommand(syncCmd)
+}

--- a/docs/HOOK_INTEGRATION.md
+++ b/docs/HOOK_INTEGRATION.md
@@ -1,0 +1,64 @@
+# Claude Code Hook Integration
+
+claudemem ships with suggested additions to Claude Code's session hooks
+so memory health is checked at session start and memory sync happens at
+session end. These are suggestions — apply them to your own hook files
+manually.
+
+For the user of this fork, the hooks live in:
+- `~/claude-code-config/global/hooks/session-memory.sh` (synced)
+- `~/claude-code-config/global/hooks/session-end-sync.sh` (synced)
+
+After editing, run `/sync push` to propagate to other machines.
+
+## session-memory.sh (SessionStart)
+
+Append after the existing `claudemem context inject` call:
+
+```bash
+# --- claudemem health parity check (P5) ---
+# Runs in <100ms on a healthy system. Prints a one-line warning if drift
+# is detected; does NOT block shell startup.
+if command -v claudemem >/dev/null 2>&1; then
+  claudemem health --quick 2>&1 | head -4
+fi
+
+# --- claudemem auto-pull (P6, opt-in) ---
+# Create ~/.claudemem/.sync_auto_pull to enable cross-machine memory sync
+# at SessionStart. Off by default to avoid surprising network calls.
+if [ -f "$HOME/.claudemem/.sync_auto_pull" ] && command -v claudemem >/dev/null 2>&1; then
+  claudemem sync pull --quiet 2>/dev/null || true
+fi
+```
+
+## session-end-sync.sh (SessionEnd)
+
+Append AFTER the existing rsync backup:
+
+```bash
+# --- claudemem auto-push (P6, opt-in) ---
+# Create ~/.claudemem/.sync_auto_push to enable cross-machine memory sync
+# at SessionEnd. Pushes committed notes/sessions to the claudemem-memory
+# remote (configured via `claudemem sync init`).
+if [ -f "$HOME/.claudemem/.sync_auto_push" ] && command -v claudemem >/dev/null 2>&1; then
+  claudemem sync push --quiet 2>/dev/null || true
+fi
+```
+
+## Enabling auto-sync on a machine
+
+```bash
+# Set up the remote first
+claudemem sync init  # interactive: asks for git remote URL
+
+# Enable auto-pull / auto-push
+touch ~/.claudemem/.sync_auto_pull
+touch ~/.claudemem/.sync_auto_push
+
+# Verify
+ls -la ~/.claudemem/.sync_auto_*
+```
+
+The two flag files live OUTSIDE config.json so they can be toggled
+per-machine without affecting the shared config. A CI server can run
+with auto-pull on + auto-push off, for example.

--- a/docs/HYBRID_EMBEDDING_PLAN.md
+++ b/docs/HYBRID_EMBEDDING_PLAN.md
@@ -1,289 +1,429 @@
-# Hybrid Embedding Backend — Implementation Plan
+# Hybrid Embedding Backend + Cross-Machine Sync — Implementation Plan v2
 
-**Status**: PLANNING (2026-04-14) — pending next-session implementation
+**Status**: APPROVED DESIGN (2026-04-14) — supersedes v1 (see git history at `cfe05bd`)
 **Owner**: Zane
-**Effort**: Phase A 5 min · Phase B 30 min · Phase C 2–6 hours
+**Effort**: 1.5–2 days focused work (all phases)
+**Branch**: `feat/embedder-interface` (worktree at `/tmp/claudemem-refactor`)
 
-## Why
+## Why this version supersedes v1
 
-Current claudemem has exactly two embedding backends:
-- **Ollama** (primary, requires local daemon)
-- **TF-IDF** (automatic fallback when Ollama unavailable)
+The v1 plan (same filename, now in git history) addressed backend pluggability only. It had five gaps that came out of a second-round review:
 
-This is brittle across machines. On web_dev, Ollama isn't installed → TF-IDF is used → semantic search is crippled (`claudemem search "多路复用器"` returns `[]` even though Zellij notes exist). The database was originally indexed on MacBook with `nomic-embed-text`, but the metadata was reset to `tfidf` during the 2026-04-14 reindex when the current backend couldn't match.
+1. **Outdated cloud ranking** — Voyage-3-large was #1; Gemini-embedding-001 now leads verified public MTEB (68.32). Voyage-3.5-lite is the new $0.02/M value pick.
+2. **Silent TF-IDF fallback preserved** — incompatible with the design rule below.
+3. **Cross-machine sync omitted** — notes/sessions are machine-siloed today; v1 didn't address it.
+4. **Per-document embedding metadata missing** — without it, backend switch = full reindex AND mixed-backend machines can't coexist.
+5. **Existing shipped work understated** — v1 described min-max hybrid fusion and backend consistency checks as "Phase C" items; both already shipped in commits `2a52f34` and `66c3fdc`. Real Phase C scope is smaller than v1 implied.
 
-Goals:
-1. **Make semantic search work on every machine** — not just MacBook.
-2. **Support pluggable backends** — local Ollama (offline, zero-cost) AND cloud APIs (best quality) via config, no recompile.
-3. **Preserve FTS** — FTS is still the right tool for exact matches (IDs, hashes, error codes). Hybrid search (FTS + vector) stays.
+## Design Rules (non-negotiable)
 
-## Research Findings — Best Embeddings (April 2026)
+1. **No silent fallback.** User explicitly picks a backend via `claudemem setup` (wizard) or `claudemem config set embedding.backend <name>` (manual). If the configured backend is unreachable, we fail loud with recovery instructions — never degrade to TF-IDF behind the user's back.
+2. **Interactive recovery when stdin is a TTY.** On backend failure during a search, offer: (a) retry, (b) fall back to FTS-only for THIS query, (c) run `claudemem setup`. Non-TTY shells get (a) = error exit only.
+3. **Per-doc embedding metadata.** Every vector row carries `(doc_id, backend, model, dim)`. Enables mixed-backend cross-machine sync, incremental re-embedding on backend switch, and clean search filtering.
+4. **Markdown is source of truth.** Cross-machine sync ships markdown only. SQLite FTS + vector indices are rebuildable from markdown, so they're never in git.
+5. **TF-IDF is a first-class choice, not a fallback.** Useful for airgapped / CI / zero-config users. Selectable in the wizard. Never auto-selected.
 
-### Local (recommended for web_dev + MacBook)
+## Research Update — April 2026 (verified)
 
-| Rank | Model | Why | Ollama command | Dim (native→recommended) |
-|------|-------|-----|----------------|--------------------------|
-| **1** | `qwen3-embedding:4b` | Bilingual Chinese+English, 32K ctx, Matryoshka truncation. Qwen3 family held MTEB Multilingual top spot 2025. | `ollama pull qwen3-embedding:4b` | 2560 → **768** |
-| 2 | `bge-m3` | Battle-tested since 2024, 100+ languages, strong Chinese, dense+sparse+ColBERT in one. | `ollama pull bge-m3` | 1024 |
-| 3 (current default) | `nomic-embed-text` | Safe fallback, small (~270MB), fast, English-heavy. Already claudemem default. | `ollama pull nomic-embed-text` | 768 |
+**Local (Ollama)**:
+| Rank | Model | Dim (native → recommended) | Chinese | Notes |
+|---|---|---|---|---|
+| **1** | `qwen3-embedding:4b` | 2560 → **768** | ✅ CN+EN primary training | MTEB multilingual top-tier. Matryoshka from 32 up. 2.5GB model |
+| 2 | `qwen3-embedding:0.6b` | 1024 → 512 | ✅ | Lighter option if 4B is slow |
+| 3 | `bge-m3` | 1024 | ✅ 100+ langs | Battle-tested fallback, dense+sparse+multivec |
 
-**Disk cost**: qwen3:4b ≈ 2.5GB, bge-m3 ≈ 1.2GB, nomic ≈ 270MB.
+**Cloud**:
+| Rank | Model | Price /1M | Dim (matryoshka) | Chinese | Third-party MTEB |
+|---|---|---|---|---|---|
+| **1 Quality** | `gemini-embedding-001` | $0.15 ($0.075 batch) | 3072 → 768/1024 | ✅ 100+ langs | **68.32 verified** |
+| 2 Value | `voyage-3.5-lite` | $0.02 (200M free) | 1024 | ✅ 26 langs | Voyage self-report only |
+| 3 Budget | `text-embedding-3-small` | $0.02 | 512 → 1536 | ⚠ English-heavy | 62.3 |
 
-### Cloud (recommended when you want better quality than local)
+Dropped from rankings: nomic-embed-text (weak Chinese), voyage-3-large (superseded by 3.5-lite at same/lower cost), text-embedding-3-large (outclassed on multilingual).
 
-| Rank | Provider/Model | Cost /1M tokens | Max input | Dim | Notes |
-|------|----------------|-----------------|-----------|-----|-------|
-| **1** | Voyage `voyage-3-large` | $0.06–0.18 | 32K | 1024 (matryoshka from 2048) | Best overall quality, ~3% ahead of OpenAI 3-large on third-party benchmarks (Agentset). 200M free tokens. |
-| Budget | OpenAI `text-embedding-3-small` | $0.02 | 8K | 512 (matryoshka from 1536) | 3× cheaper than 3-large, serviceable Chinese, widely compatible tooling. |
-| Not recommended | OpenAI `text-embedding-3-large` | $0.13 | 8K | 3072 | Outclassed by voyage-3-large on quality AND cost. Include only as reference. |
+For a 3K-note bilingual corpus, Gemini-001 at 768-dim matryoshka runs ~$0.50/month. Local qwen3-4b at 768-dim uses ~6MB of vectors total. Both are practical.
 
-### Caveats (must flag before acting)
-
-- **MTEB v1 vs v2 scores are NOT comparable.** Don't treat aggregator leaderboards as apples-to-apples.
-- **Voyage's "+9.7% vs OpenAI" is vendor marketing.** Third-party benchmarks (Agentset) show ~3% — directionally correct, magnitude inflated.
-- **Qwen3 Ollama quantization quality on Chinese retrieval is unverified** — no public C-MTEB for `qwen3-embedding:4b-q4_K_M`.
-- Research done via Claude subagent (web search + MTEB HF space + vendor docs). Cross-reference before spending money.
-
-Full research trace: session `fa4d137a` (2026-04-14) + note `86629e7e`.
-
-## Current Architecture (verified from source)
-
-Source: `~/claudemem/pkg/vectors/` — **this is Zane's own fork** (github.com/zelinewang/claudemem).
+## Architecture
 
 ```
 pkg/vectors/
-├── store.go        # VectorStore — orchestrates backends, init logic
-├── ollama.go       # OllamaEmbedder — concrete HTTP client to localhost:11434
-├── tfidf.go        # Vectorizer — TF-IDF fallback
-└── *_test.go
+├── embedder.go         NEW: Embedder interface, InputType enum, common errors
+├── ollama.go           REFACTORED: implement Embedder; add Name()/Dimensions()
+├── gemini.go           NEW: Google Gemini Embedding API client
+├── voyage.go           NEW: Voyage AI client with document/query modes
+├── openai.go           NEW: OpenAI embeddings
+├── tfidf.go             KEPT: now implements Embedder (TF-IDFEmbedder)
+├── store.go            REFACTORED: Embedder-based, no type switches
+├── registry.go         NEW: factory — name → Embedder constructor
+└── health.go           NEW: invariant checks (I1–I5)
+
+pkg/config/
+├── config.go            EXTENDED: typed EmbedderConfig struct + secret-guard
+└── wizard.go           NEW: interactive setup (claudemem setup command)
+
+cmd/
+├── setup.go            NEW: wraps wizard.go for CLI surface
+├── health.go           NEW: claudemem health / verify --deep
+└── sync.go             NEW: claudemem sync {pull, push, status, init}
+
+pkg/sync/
+├── gitsync.go          NEW: markdown-only git sync orchestration
+└── reconcile.go        NEW: post-pull reconciliation (rebuild index, re-embed missing)
 ```
 
-Key code observations:
+### Embedder interface
 
-- `VectorStore` struct has **concrete fields**, not interface:
-  ```go
-  type VectorStore struct {
-      db         *sql.DB
-      vectorizer *Vectorizer       // TF-IDF fallback
-      ollama     *OllamaEmbedder   // Ollama primary (nil if unavailable)
-      useOllama  bool
-  }
-  ```
-- `tryInitOllama(model string)` hardcodes the single init path.
-- `OllamaEmbedder.baseURL` hardcoded to `"http://localhost:11434"` (ollama.go:43).
-- Default model `"nomic-embed-text"` hardcoded in `NewOllamaEmbedder` (ollama.go:40).
-- Config system (`~/.claudemem/config.json`) is Cobra/Viper-style key-value — `claudemem config set/get/list/delete` works but only `features.semantic_search` is actively read today.
-
-**Gap**: There is no `Embedder` interface. Adding cloud requires introducing one AND refactoring `VectorStore` to depend on the interface.
-
-## Implementation Plan
-
-### Phase A — Install Ollama on web_dev (5 minutes)
-
-**Goal**: get semantic search working TODAY with the existing claudemem default.
-
-Blocker encountered this session: official install script needs sudo (not available); manual tarball URL returned 404 (release layout changed to `.tar.zst`). Two options:
-
-**Option A1 — Official installer via user sudo** (preferred if user can sudo interactively)
-```bash
-curl -fsSL https://ollama.com/install.sh | sh
-# Prompts for sudo password; installs to /usr/local and creates systemd service.
-```
-
-**Option A2 — User-local install (no sudo)**
-```bash
-# Find current release asset name (format changed to tar.zst)
-LATEST=$(curl -sL https://api.github.com/repos/ollama/ollama/releases/latest \
-  | grep -oE '"browser_download_url":\s*"[^"]+linux-amd64\.tar\.zst"' | head -1 \
-  | cut -d'"' -f4)
-curl -fsSL "$LATEST" -o /tmp/ollama.tar.zst
-
-# Need zstd to extract. Install if missing:
-command -v zstd || sudo apt install -y zstd
-# (or: download prebuilt zstd binary to ~/.local/bin — but apt is simpler)
-
-# Extract to ~/.local
-mkdir -p ~/.local
-tar --zstd -xf /tmp/ollama.tar.zst -C ~/.local/
-# Produces ~/.local/bin/ollama + ~/.local/lib/ollama/
-
-# Start service in background
-~/.local/bin/ollama serve &
-# (better: create systemd --user service or fish conf.d launcher)
-
-# Pull default model to match claudemem's hardcoded default
-~/.local/bin/ollama pull nomic-embed-text
-```
-
-**Verification**:
-```bash
-curl -s http://localhost:11434/api/tags | jq '.models[].name'
-# Should include: "nomic-embed-text:latest"
-```
-
-Then rebuild claudemem's vector index:
-```bash
-claudemem reindex --vectors
-# Expected output: "Vector index rebuilt: 1086 documents indexed (backend: ollama)"
-```
-
-**Success criterion**:
-```bash
-claudemem search "多路复用器" --limit 3 --format json
-# Should return Zellij-related notes via semantic match.
-# Currently returns [] under tfidf.
-```
-
-### Phase B — Upgrade to qwen3-embedding:4b (optional, 30 minutes)
-
-**Goal**: bilingual retrieval quality for Chinese/English mixed notes.
-
-```bash
-ollama pull qwen3-embedding:4b    # ~2.5GB
-```
-
-Problem: claudemem hardcodes `nomic-embed-text`. To use qwen3 without code changes, the cleanest path is to tag it as the model alias Ollama uses internally. But since claudemem pulls from the `NewOllamaEmbedder(model)` path that defaults to `"nomic-embed-text"`, the only runtime lever today is the (private) `NewVectorStoreWithModel(db, model)` entry point — not exposed via CLI.
-
-**Three ways to force a different model**:
-
-1. **Cheap hack**: `ollama cp nomic-embed-text nomic-embed-text-backup && ollama cp qwen3-embedding:4b nomic-embed-text` — aliases qwen3 under nomic's name. Works but confusing.
-2. **Surgical patch**: change the hardcoded string in `pkg/vectors/ollama.go:40`, rebuild, replace binary. Fast, reversible via git.
-3. **Wait for Phase C** (config-driven model selection). Recommended.
-
-### Phase C — Pluggable Embedding Backend (2–6 hours, the real work)
-
-**Scope**: introduce `Embedder` interface + 2 new backends (OpenAI, Voyage) + config-driven dispatch + backend consistency checks that include backend name + model.
-
-#### C.1 — Define the interface (30 min)
-
-New file: `pkg/vectors/embedder.go`
 ```go
-package vectors
+// InputType tells multi-mode backends which optimization to apply.
+// Ollama/TF-IDF ignore it. Voyage/Gemini use it.
+type InputType string
+const (
+    InputTypeDocument InputType = "document"
+    InputTypeQuery    InputType = "query"
+)
 
-// Embedder produces dense vector embeddings from text.
-// Implementations: OllamaEmbedder (local), OpenAIEmbedder, VoyageEmbedder.
+// Embedder produces dense vector embeddings.
 type Embedder interface {
-    // Available reports whether the backend is reachable and the model is loaded.
-    Available() bool
-    // Embed returns the embedding for a single input.
-    Embed(text string) ([]float32, error)
-    // EmbedBatch returns embeddings for multiple inputs in one round-trip.
-    EmbedBatch(texts []string) ([][]float32, error)
-    // Model returns the model identifier (e.g. "nomic-embed-text", "voyage-3-large").
-    Model() string
-    // Dimensions returns the embedding vector length (after any truncation).
-    Dimensions() int
-    // Name returns the backend name (e.g. "ollama", "openai", "voyage") for
-    // consistency checks and logging.
-    Name() string
+    // Available checks if the backend is reachable NOW. Not cached — every call.
+    Available() error             // returns nil if healthy, error with recovery hint otherwise
+    Embed(text string, t InputType) ([]float32, error)
+    EmbedBatch(texts []string, t InputType) ([][]float32, error)
+    Name() string                 // "ollama" | "gemini" | "voyage" | "openai" | "tfidf"
+    Model() string                // "qwen3-embedding:4b" | "gemini-embedding-001" | ...
+    Dimensions() int              // after any matryoshka truncation
 }
 ```
 
-Refactor `VectorStore`:
+Key design choice: `Available()` returns an **error with a recovery hint**, not a bool. This enables the fail-loud rule — the error message tells the user exactly what to do (`ollama serve`, `export GEMINI_API_KEY=...`, `claudemem setup`).
+
+### Vectors table schema (migration v22)
+
+```sql
+-- OLD: CREATE TABLE vectors (id TEXT PRIMARY KEY, vector BLOB)
+
+-- NEW:
+CREATE TABLE vectors (
+    doc_id TEXT NOT NULL,
+    backend TEXT NOT NULL,       -- "ollama" | "gemini" | "voyage" | "openai" | "tfidf"
+    model TEXT NOT NULL,          -- "qwen3-embedding:4b" | "gemini-embedding-001" | ...
+    dim INTEGER NOT NULL,
+    vector BLOB NOT NULL,
+    created_at TEXT NOT NULL,
+    PRIMARY KEY (doc_id, backend, model)
+);
+CREATE INDEX idx_vectors_backend ON vectors(backend, model);
+CREATE INDEX idx_vectors_doc ON vectors(doc_id);
+```
+
+Search becomes: `SELECT vector FROM vectors WHERE doc_id IN (...) AND backend = ? AND model = ?`.
+
+**Migration strategy (preserve existing vectors, don't drop)**:
+
+On first run with new binary, detect old-schema `vectors` table via `PRAGMA table_info(vectors)`:
+
 ```go
-type VectorStore struct {
-    db         *sql.DB
-    vectorizer *Vectorizer   // kept as ultimate fallback
-    embedder   Embedder      // replaces *OllamaEmbedder; nil means tfidf-only
+// Pseudocode for pkg/storage/migrations/v22.go
+func MigrateV22(db *sql.DB) error {
+    if !hasOldVectorsSchema(db) { return nil }   // already migrated
+
+    // 1. Read what backend produced the existing rows
+    var indexedBackend string
+    db.QueryRow("SELECT value FROM vector_meta WHERE key='index_backend'").Scan(&indexedBackend)
+    // e.g. "ollama:nomic-embed-text" or "tfidf"
+    backend, model := parseBackendTuple(indexedBackend)
+    dim := readDimensionFromFirstRow(db)          // inspect blob length / 4
+
+    // 2. Rename old table
+    db.Exec("ALTER TABLE vectors RENAME TO vectors_v21")
+
+    // 3. Create new schema
+    db.Exec(newV22Schema)
+
+    // 4. Copy every old row with backend/model/dim stamped
+    db.Exec(`INSERT INTO vectors (doc_id, backend, model, dim, vector, created_at)
+             SELECT id, ?, ?, ?, vector, datetime('now') FROM vectors_v21`,
+            backend, model, dim)
+
+    // 5. Drop old table (data preserved in new)
+    db.Exec("DROP TABLE vectors_v21")
+    return nil
 }
 ```
 
-Rename `tryInitOllama` → `initEmbedderFromConfig(cfg EmbedderConfig)` that dispatches on `cfg.Backend`.
+Result:
+- **web_dev**: old rows were TF-IDF (degraded); migration preserves them tagged as `("tfidf", "tfidf", dim)`. User can run `claudemem setup` to switch to Gemini/Ollama then `reindex --vectors` to get quality semantic search.
+- **MacBook**: old rows were real Ollama embeddings (`nomic-embed-text` 768-dim); migration preserves them as `("ollama", "nomic-embed-text", 768)`. Zero re-embed cost. User can switch backend any time; old vectors stay queryable under `backend="ollama"`.
+- **Cross-machine sync**: after first sync, MacBook's Ollama vectors and web_dev's Gemini vectors coexist in the same table on both machines (each machine's queries filter by its own configured backend).
 
-#### C.2 — Config schema (30 min)
+### Config schema
 
-Add keys readable via `claudemem config get/set`:
 ```
-embedding.backend         = ollama | openai | voyage | tfidf
-embedding.model           = nomic-embed-text | qwen3-embedding:4b | voyage-3-large | text-embedding-3-small
-embedding.dimensions      = 768    (optional — matryoshka truncation)
-embedding.api_key_env     = VOYAGE_API_KEY | OPENAI_API_KEY  (for cloud backends)
-embedding.endpoint        = http://localhost:11434 | https://api.voyageai.com/v1/embeddings  (override URL)
-embedding.timeout_seconds = 30
-```
-
-Config load order:
-1. `~/.claudemem/config.json` (explicit user choice)
-2. Env var `CLAUDEMEM_EMBEDDING_BACKEND` (runtime override)
-3. Auto-detect: if ollama reachable → ollama, else if `VOYAGE_API_KEY` set → voyage, else tfidf.
-
-#### C.3 — OpenAIEmbedder (45 min)
-
-New file: `pkg/vectors/openai.go`
-```go
-// POST https://api.openai.com/v1/embeddings
-// Body: {"model": "text-embedding-3-small", "input": ["text1", "text2"], "dimensions": 512}
-// Header: Authorization: Bearer $OPENAI_API_KEY
-```
-- Matryoshka: pass `dimensions` field to truncate server-side (cheaper transfer).
-- Batch limit: 2048 inputs per request, 8191 tokens per input.
-- Error handling: 429 (rate limit) → exponential backoff 3×; 401 → fail loud.
-
-#### C.4 — VoyageEmbedder (45 min)
-
-New file: `pkg/vectors/voyage.go`
-```go
-// POST https://api.voyageai.com/v1/embeddings
-// Body: {"model": "voyage-3-large", "input": ["text1"], "input_type": "document", "output_dimension": 1024}
-// Header: Authorization: Bearer $VOYAGE_API_KEY
-```
-- `input_type` = `"document"` for notes, `"query"` for searches. Separate code paths.
-- Max 128 inputs per batch, 32K tokens per input.
-- Response shape similar to OpenAI.
-
-#### C.5 — Backend consistency checks (30 min)
-
-Currently `checkBackendConsistency` compares `"ollama"` vs `"tfidf"` only. Extend to `backend:model` tuple (`"ollama:nomic-embed-text"` vs `"voyage:voyage-3-large"`) so switching model — not just backend — triggers a reindex warning.
-
-Store in `vector_meta` table (already exists):
-```
-key = "vectorizer_state"  → JSON {"backend": "voyage", "model": "voyage-3-large", "dimensions": 1024}
+embedding.backend       = "ollama" | "gemini" | "voyage" | "openai" | "tfidf"
+embedding.model         = model name (e.g., "gemini-embedding-001")
+embedding.dimensions    = optional matryoshka truncation target
+embedding.input_type    = "document" (default) — most users don't touch
+embedding.api_key_env   = "GEMINI_API_KEY" | "VOYAGE_API_KEY" | "OPENAI_API_KEY"
+embedding.endpoint      = optional URL override (for proxies)
+embedding.on_failure    = "error" (default) | "fts_only" | "prompt"
 ```
 
-#### C.6 — Tests + README (30 min)
+**Secret guard**: `config set embedding.api_key ...` (without `_env` suffix) rejects with error. Secrets are ONLY env vars.
 
-- Unit: mock HTTP server for OpenAI/Voyage, assert request shape + response parsing.
-- E2E: add `e2e_test.sh` case that sets `OPENAI_API_KEY` from env (if set) and does a round-trip. Skip if env var missing — don't fail CI.
-- README: new `## Embedding Backends` section with config examples per backend.
+## Setup wizard UX
 
-#### C.7 — Migration path for existing users (15 min)
+```
+$ claudemem setup
+claudemem — Memory Setup
 
-Existing users with ollama-indexed DBs on MacBook: Phase C release should NOT break them. Strategy:
-- If no `embedding.backend` key in config → fall back to current auto-detect behavior.
-- If `vector_meta.vectorizer_state` was written by old format (just `"ollama"`) → treat as `"ollama:nomic-embed-text"`.
-- Log a one-line deprecation warning, don't force reindex.
+Which embedding backend do you want to use?
 
-### Verification criteria (all three phases)
+  1) Local — Ollama (offline, zero cost, recommended for daily use)
+  2) Cloud — Gemini (best quality, ~$0.15/M tokens, requires API key)
+  3) Cloud — Voyage (best value, effectively free <200M tokens)
+  4) Cloud — OpenAI (widely available, weaker Chinese)
+  5) No semantic search — TF-IDF only (keyword-ish, no daemon/key needed)
+
+> 1
+
+[Ollama path]
+  Checking http://localhost:11434 ... ✓ reachable
+  Which model?
+    1) qwen3-embedding:4b  (bilingual, 2.5GB, recommended)
+    2) bge-m3              (100+ languages, 1.2GB)
+    3) nomic-embed-text    (small, 270MB, English-heavy)
+    4) Other (enter name)
+
+  > 1
+  Model not installed. Pull now? [Y/n] y
+  (pulls qwen3-embedding:4b via ollama pull...)
+
+  Matryoshka dimension (recommended 768 for <5k notes) [768]: ⏎
+  Testing embedding: "hello world" ... ✓ got 768-dim vector
+  Saved to ~/.claudemem/config.json
+
+[Gemini path]
+  Environment variable GEMINI_API_KEY: set ✓
+  Which model?
+    1) gemini-embedding-001 (recommended, 768-dim matryoshka)
+  > 1
+  Testing embedding ... ✓ got 768-dim vector
+  Saved.
+
+Rebuild vector index with new backend now? [Y/n] y
+Indexing 1086 documents ... ✓ done in 42s (backend: gemini:gemini-embedding-001)
+```
+
+Equivalent manual path (documented in CLI help):
+```
+claudemem config set embedding.backend gemini
+claudemem config set embedding.model gemini-embedding-001
+claudemem config set embedding.dimensions 768
+claudemem config set embedding.api_key_env GEMINI_API_KEY
+claudemem reindex --vectors
+```
+
+## Failure-mode UX
+
+Non-TTY (CI, scripts):
+```
+$ claudemem search "multiplexer"
+Error: embedding backend `ollama:qwen3-embedding:4b` unreachable: connection refused
+  Recovery options:
+    - Start Ollama: ollama serve
+    - Switch backend: claudemem setup
+    - Search FTS-only this once: claudemem search "multiplexer" --fts-only
+Exit 1
+```
+
+TTY (interactive):
+```
+$ claudemem search "multiplexer"
+⚠ Embedding backend `ollama:qwen3-embedding:4b` unreachable: connection refused
+What do you want to do?
+  1) Retry
+  2) Search FTS-only for this query
+  3) Run `claudemem setup` to switch backend
+  4) Exit
+> _
+```
+
+Never silently returns TF-IDF results.
+
+## Cross-machine sync
+
+### Architecture
+
+```
+┌────────────────┐           ┌────────────────┐
+│   web_dev      │           │    MacBook     │
+│  ~/.claudemem  │           │  ~/.claudemem  │
+├────────────────┤           ├────────────────┤
+│ notes/*.md     │◄─ git ──►│ notes/*.md     │
+│ sessions/*.md  │◄─ git ──►│ sessions/*.md  │
+│ config.json    │ (local)   │ config.json    │  ← per-machine
+│ .index/*.db    │ (local)   │ .index/*.db    │  ← per-machine, rebuilt
+└────────────────┘           └────────────────┘
+       ↓                            ↓
+   Gemini vectors              Ollama vectors
+   stored in local DB          stored in local DB
+   (backend=gemini)             (backend=ollama)
+```
+
+### Repo choice
+
+**Decision: new repo `~/claudemem-memory` (separate from claude-code-config)**, remote `git@github.com:zelinewang/claudemem-memory` (private). Rationale:
+- claudemem-memory contains personal knowledge (not shareable config)
+- claude-code-config is already multi-machine-aware but targets tools, not data
+- Separate privacy boundary (claude-code-config might go public one day; memory never)
+- Single-purpose: one repo = one concern (Doctrine 2)
+
+### Commands
+
+```
+claudemem sync init     # first run: git init in ~/.claudemem, configure remote, gitignore .index/ and config.json
+claudemem sync push     # commit notes/ sessions/ MEMORY.md changes, git push
+claudemem sync pull     # git pull, then reconcile (rebuild FTS, re-embed missing for configured backend)
+claudemem sync status   # git status + index health report
+```
+
+### Reconcile (`claudemem sync pull` internal):
+1. `git pull` (fast-forward or merge, with markdown-aware conflict strategy)
+2. `reindex --fts` (quick — just re-populates SQLite FTS from markdown)
+3. Scan vectors table: `SELECT doc_id FROM entries WHERE id NOT IN (SELECT doc_id FROM vectors WHERE backend=? AND model=?)`
+4. Embed missing docs with configured backend (cost: only NEW docs since last pull)
+5. Report: "Reconciled 17 new notes, embedded with gemini:gemini-embedding-001 in 3.2s"
+
+### Hooks integration
+
+Extend `~/.claude/hooks/session-memory.sh`:
+```bash
+# On SessionStart: offer auto-pull if enabled
+if [ -f "$HOME/.claudemem/.sync_auto_pull" ]; then
+    claudemem sync pull --quiet || echo "⚠ claudemem sync pull failed (not fatal)"
+fi
+# Existing context inject:
+claudemem context inject --limit 5
+# NEW: health parity check
+claudemem health --quick || echo "⚠ memory index drift detected. Run 'claudemem repair'."
+```
+
+Extend `~/.claude/hooks/session-end-sync.sh`:
+```bash
+# After wrapup, auto-push if enabled
+if [ -f "$HOME/.claudemem/.sync_auto_push" ]; then
+    claudemem sync push --quiet || true
+fi
+# Existing rsync backup stays as belt-and-braces.
+```
+
+## Health / parity check subsystem
+
+`claudemem health` (cheap, <100ms):
+- I1: `COUNT(entries) == COUNT(markdown files)`
+- I2: `COUNT(entries) == COUNT(memory_fts)`
+- I3: For each `(backend, model)` in use: `COUNT(vectors WHERE backend=? AND model=?) == COUNT(entries)`
+- Exit 0 if all pass, 1 + warning message if drift.
+
+`claudemem health --deep` (slower):
+- I4: No orphan FTS/vector rows pointing to nonexistent entries
+- I5: `vector_meta.vectorizer_state` matches active config
+- Verify a sample of 10 random vectors by re-embedding and comparing cosine similarity > 0.99
+
+`claudemem repair`:
+- Runs health, offers fixes (prompt in TTY, auto in --yes mode)
+- "Rebuild FTS from markdown? [Y/n]" → runs reindex --fts
+- "Re-embed 17 missing docs with gemini:gemini-embedding-001? [Y/n]" → runs partial embed
+
+## Implementation phases (value-ordered)
+
+**Phase 1 — Embedder interface foundation (3h)**
+- Write `pkg/vectors/embedder.go` (interface + InputType + errors)
+- Refactor `ollama.go` to implement the interface (add `Name()`, fix `Model()`/`Dimensions()` signatures)
+- Refactor `tfidf.go` to implement the interface
+- Refactor `store.go`: `VectorStore.embedder Embedder` field replacing concrete ollama/tfidf fields; remove `useOllama bool`; remove all type switches
+- Schema migration v22 (add backend/model/dim columns, composite PK)
+- Unit tests: interface contract test applied to both implementations
+
+**Phase 2 — Add Gemini provider (2h)**
+- Write `pkg/vectors/gemini.go` using `google.golang.org/genai` Go client
+- Wire into registry.go factory
+- Unit test with `httptest` mock
+- Live smoke test against real API (requires `GEMINI_API_KEY`)
+
+**Phase 3 — Setup wizard (2h)**
+- Write `pkg/config/wizard.go` (survey via prompts)
+- Write `cmd/setup.go` CLI surface
+- Environment detection (check Ollama reachable, check env vars)
+- Verify step: test embedding + recorded dim
+- Auto-trigger reindex after successful setup
+
+**Phase 4 — Fail-loud + interactive recovery (1.5h)**
+- Replace `tryInitOllama()` silent fallback with explicit config read + fail-loud
+- Write interactive recovery prompt in `cmd/search.go` (TTY-detected)
+- `--fts-only` flag on search command
+- Unit tests for non-TTY error path
+
+**Phase 5 — Health/repair subsystem (2h)**
+- Write `pkg/vectors/health.go` (I1–I5 invariants)
+- Write `cmd/health.go` and `cmd/repair.go`
+- Extend `session-memory.sh` hook with `--quick` call
+- Unit tests for drift detection
+
+**Phase 6 — Cross-machine sync (4h)**
+- Write `pkg/sync/gitsync.go` (delegates to git CLI via `os/exec`)
+- Write `pkg/sync/reconcile.go` (post-pull re-embed logic)
+- Write `cmd/sync.go` (init/push/pull/status subcommands)
+- `.gitignore` generation (excludes `.index/`, `config.json`, `.sync_auto_*`)
+- Test: two temp dirs, push from one, pull from other, verify equivalence
+- Extend `session-memory.sh` and `session-end-sync.sh` with optional auto-sync hooks
+
+**Phase 7 — Voyage + OpenAI providers (2h, parallelizable)**
+- Add `voyage.go` and `openai.go` implementing Embedder
+- Tests with httptest mocks
+- Lower priority than Gemini since Gemini is the new cloud default
+
+**Phase 8 — Docs + PR (1h)**
+- Update README.md with Setup section
+- Update SKILL.md in `skills/claudemem/` directories
+- Update CLAUDE.md if claudemem commands changed
+- Open PR with summary + migration note
+
+**Total: ~17.5h = 2 focused days**
+
+## Acceptance criteria
 
 After each phase, these must pass:
 
-| Test | Expected |
-|------|----------|
-| `claudemem stats` | No warning about backend mismatch |
-| `claudemem search "zellij" --limit 3` | Returns zellij notes (FTS still works) |
-| `claudemem search "多路复用器" --limit 3` | Returns zellij notes via semantic match (proves vector works for cross-language) |
-| `claudemem search "config drift"` | Returns notes about config, not just literal-word matches (proves semantic) |
-| `claudemem reindex --vectors` output | `backend: <name>` matches config |
+| Gate | Test |
+|---|---|
+| Interface contract | Both Ollama + TF-IDF pass same unit test suite (Embed returns correct-dim vector, Available returns error with recovery hint, Name/Model/Dimensions consistent) |
+| Gemini smoke | `GEMINI_API_KEY=... claudemem setup` → picks Gemini → reindex succeeds → `claudemem search "多路复用器"` returns Zellij notes |
+| Fail-loud | Kill Ollama daemon, run `claudemem search "x"` → exits 1 with recovery message, does NOT return TF-IDF results |
+| Per-doc metadata | Index 5 docs with Ollama, switch to Gemini, reindex — vectors table has 10 rows (5 ollama + 5 gemini); search under each backend returns correct results independently |
+| Health drift | Delete a markdown file manually → `claudemem health` reports drift; `claudemem repair` offers to remove orphan entry |
+| Sync round-trip | Worktree A: add note, push; Worktree B: pull → markdown present, FTS contains it, vector created under B's backend |
+| Hooks | SessionStart hook runs health --quick in <200ms and doesn't block shell |
 
-## Open Decisions (user input needed before Phase C)
+## Open decisions (small, can resolve as we go)
 
-1. **Local vs Cloud default** — should claudemem default to Ollama if available, even if `VOYAGE_API_KEY` is set? Proposal: yes, prefer local (zero cost, offline). Cloud is opt-in via explicit `embedding.backend = voyage`.
-2. **Upstream this?** — Phase C is a meaningful feature. Worth a PR to upstream claudemem? Or keep in personal fork? Proposal: ship in fork first, polish via real use, then upstream if stable.
-3. **Chinese-heavy content** — real usage split between Chinese and English notes? If 80%+ Chinese, qwen3/voyage multilingual are must-haves. If 80%+ English, nomic/OpenAI are fine.
-4. **API key storage** — env var (`VOYAGE_API_KEY`) vs config file. Proposal: env var only. Config file should NEVER store secrets (git safety).
-5. **Priority**: Phase A blocking (do first), Phase B optional, Phase C is the real investment. Confirm before allocating 2-6 hours.
+1. **Auto-pull on SessionStart by default?** Proposal: opt-in via `touch ~/.claudemem/.sync_auto_pull`. Reason: unexpected network calls on session start are surprising.
+2. **Markdown conflict strategy on pull?** Proposal: append-with-separator merge (mirrors existing note-dedup logic), not git merge. Reason: markdown notes don't have meaningful diffs — keep both.
+3. **Batch size for initial reindex?** Gemini allows 250/batch, Voyage 128, Ollama 50. Proposal: let each embedder expose `MaxBatchSize()` and let RebuildIndex respect it.
+4. **Should `claudemem health --quick` run on every search?** Proposal: no — only at SessionStart (once per session). Cache a freshness token.
+5. **sqlite-vec library?** For <10K docs, brute-force is fine (<50ms). Defer to future — not in this refactor.
 
-## Risks & Mitigations
+## Risks & mitigations
 
-- **Ollama service crashes mid-session** → claudemem should detect and fall back to tfidf gracefully without losing user queries. Current `Available()` check only runs on init — needs per-call retry.
-- **API key leak** → always read from env, never from config file. Add `config set embedding.api_key ...` → reject with error.
-- **Dimension mismatch on backend switch** → old vectors (768 dim from nomic) incompatible with new (1024 dim from voyage). `checkBackendConsistency` must BLOCK queries until reindex completes, not just warn. Currently warns only.
-- **Vendor lockin** → if Voyage raises prices, need fast migration path to OpenAI. The interface abstraction handles this.
+- **Gemini API changes** (preview → GA) — wrap in versioned client; pin API version in config.
+- **Git conflicts on markdown** — mitigated by append-with-separator merge policy + timestamp metadata.
+- **Accidentally commit secrets** — `config set api_key` rejects (secret guard); `.gitignore` excludes config.json; pre-commit hook in claudemem-memory repo greps for common key prefixes.
+- **Backend switch orphans old vectors** — NOT dropped automatically; `claudemem vacuum` cleans unused (backend, model) rows explicitly.
+- **Cross-machine clock drift affects timestamps in markdown merges** — use session_id (UUID) as primary dedup key, not timestamp.
 
 ## References
 
-- Session 2026-04-14 (claudemem `fa4d137a`) — research + architecture investigation trace
-- Note `92d9f5ab` — Zellij 0.43 layout gotchas (peripheral)
-- Note `86629e7e` — 3-axis decision framework (not directly used here but shows methodology)
-- Source files investigated: `~/claudemem/pkg/vectors/store.go`, `~/claudemem/pkg/vectors/ollama.go`
-- External: https://huggingface.co/spaces/mteb/leaderboard, https://blog.voyageai.com, https://platform.openai.com/docs/guides/embeddings
+- Current architecture source: `pkg/vectors/store.go` (413 LOC, inspected 2026-04-14)
+- Previous plan: git `cfe05bd` (superseded by this doc)
+- Research: MTEB leaderboard, Qwen3 HF, Gemini Embedding API docs, Voyage docs, BentoML 2026 guide, Premai RAG ranking
+- Hook integration map: `~/.claude/hooks/session-memory.sh`, `~/.claude/hooks/session-end-sync.sh`, `~/.claude/commands/wrapup.md`
+- Cross-machine host repo: `~/claude-code-config/` (3-tier sync system, separate from this plan)

--- a/docs/HYBRID_EMBEDDING_PLAN.md
+++ b/docs/HYBRID_EMBEDDING_PLAN.md
@@ -287,11 +287,16 @@ claudemem sync status   # git status + index health report
 ```
 
 ### Reconcile (`claudemem sync pull` internal):
-1. `git pull` (fast-forward or merge, with markdown-aware conflict strategy)
-2. `reindex --fts` (quick — just re-populates SQLite FTS from markdown)
-3. Scan vectors table: `SELECT doc_id FROM entries WHERE id NOT IN (SELECT doc_id FROM vectors WHERE backend=? AND model=?)`
-4. Embed missing docs with configured backend (cost: only NEW docs since last pull)
-5. Report: "Reconciled 17 new notes, embedded with gemini:gemini-embedding-001 in 3.2s"
+1. `git pull --ff-only` (fast-forward only — no auto-merge for markdown)
+2. `Reindex()` (rebuilds the SQLite entries + memory_fts from markdown)
+3. `ReindexVectors()` (wipes + rebuilds vectors for the active `(backend, model)` only; rows from other backends preserved for cross-machine coexistence)
+4. Report: "Reconciled N FTS entries + M vectors (backend: <name>)"
+
+**Note**: The current implementation does a full reindex-for-active-backend
+on each pull, not a diff-based incremental embed. For corpora up to ~5K
+notes this is ~<30s with Gemini and acceptable. A future optimization
+would be to diff the last-synced git SHA against HEAD and embed only
+changed files; tracked in open decisions #3.
 
 ### Hooks integration
 

--- a/pkg/config/wizard.go
+++ b/pkg/config/wizard.go
@@ -50,8 +50,8 @@ func RunSetupWizard(opts WizardOptions) (*WizardResult, error) {
 	fmt.Fprintln(opts.Out, "")
 	fmt.Fprintln(opts.Out, "  1) Local — Ollama         (offline, zero cost, recommended for daily use)")
 	fmt.Fprintln(opts.Out, "  2) Cloud — Gemini         (best quality, ~$0.15/M tokens, requires API key)")
-	fmt.Fprintln(opts.Out, "  3) Cloud — Voyage         (budget pick, $0.02/M, [not yet implemented, lands in P7])")
-	fmt.Fprintln(opts.Out, "  4) Cloud — OpenAI         (widely available, weaker Chinese, [not yet implemented, lands in P7])")
+	fmt.Fprintln(opts.Out, "  3) Cloud — Voyage         (budget pick, $0.02/M, 200M free tokens)")
+	fmt.Fprintln(opts.Out, "  4) Cloud — OpenAI         (widely available, weaker Chinese)")
 	fmt.Fprintln(opts.Out, "  5) No semantic search     — TF-IDF (keyword-ish; no daemon/key needed)")
 	fmt.Fprintln(opts.Out, "")
 
@@ -66,9 +66,9 @@ func RunSetupWizard(opts WizardOptions) (*WizardResult, error) {
 	case 2:
 		return setupGemini(opts.Out, r, opts.StoreDir)
 	case 3:
-		return nil, fmt.Errorf("voyage backend lands in P7 — pick another for now")
+		return setupVoyage(opts.Out, r, opts.StoreDir)
 	case 4:
-		return nil, fmt.Errorf("openai backend lands in P7 — pick another for now")
+		return setupOpenAI(opts.Out, r, opts.StoreDir)
 	case 5:
 		return setupTFIDF(opts.Out, r)
 	}
@@ -222,6 +222,121 @@ func setupGemini(w io.Writer, r *bufio.Reader, storeDir string) (*WizardResult, 
 	return &WizardResult{
 		Config: vectors.BackendConfig{
 			Backend: "gemini",
+			Model:   model,
+			APIKey:  key,
+			Dim:     dim,
+		},
+		APIKeyEnvVar: envVarName,
+		RunReindex:   confirmReindex(w, r),
+	}, nil
+}
+
+// --- Voyage path ---
+
+func setupVoyage(w io.Writer, r *bufio.Reader, storeDir string) (*WizardResult, error) {
+	const envVarName = "VOYAGE_API_KEY"
+	key := os.Getenv(envVarName)
+	if key == "" {
+		fmt.Fprintf(w, "\nEnvironment variable %s is NOT set.\n", envVarName)
+		fmt.Fprintln(w, "claudemem never stores API keys in config files. Set the env var and re-run.")
+		fmt.Fprintf(w, "\n  export %s=your-key-here\n  claudemem setup\n\n", envVarName)
+		fmt.Fprintln(w, "Get a key at: https://dash.voyageai.com/api-keys")
+		return nil, fmt.Errorf("%s not set in environment", envVarName)
+	}
+	fmt.Fprintf(w, "Environment variable %s: set ✓\n", envVarName)
+
+	fmt.Fprintln(w, "\nWhich model?")
+	fmt.Fprintln(w, "  1) voyage-3.5-lite   (recommended — $0.02/M, 200M free tokens)")
+	fmt.Fprintln(w, "  2) voyage-3.5        (higher quality, $0.06/M)")
+	fmt.Fprintln(w, "  3) voyage-3-large    (legacy — kept for users already on it)")
+	choice, err := promptChoice(w, r, "> ", 3)
+	if err != nil {
+		return nil, err
+	}
+	var model string
+	switch choice {
+	case 1:
+		model = "voyage-3.5-lite"
+	case 2:
+		model = "voyage-3.5"
+	case 3:
+		model = "voyage-3-large"
+	}
+
+	dim, err := promptDim(w, r, 1024)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprint(w, "Testing embedding ... ")
+	emb := vectors.NewVoyageEmbedder(model, key, dim)
+	vec, err := emb.Embed("hello world", vectors.InputTypeDocument)
+	if err != nil {
+		fmt.Fprintln(w, "FAIL")
+		return nil, fmt.Errorf("voyage test embed failed: %w", err)
+	}
+	fmt.Fprintf(w, "✓ got %d-dim vector\n", len(vec))
+
+	return &WizardResult{
+		Config: vectors.BackendConfig{
+			Backend: "voyage",
+			Model:   model,
+			APIKey:  key,
+			Dim:     dim,
+		},
+		APIKeyEnvVar: envVarName,
+		RunReindex:   confirmReindex(w, r),
+	}, nil
+}
+
+// --- OpenAI path ---
+
+func setupOpenAI(w io.Writer, r *bufio.Reader, storeDir string) (*WizardResult, error) {
+	const envVarName = "OPENAI_API_KEY"
+	key := os.Getenv(envVarName)
+	if key == "" {
+		fmt.Fprintf(w, "\nEnvironment variable %s is NOT set.\n", envVarName)
+		fmt.Fprintf(w, "\n  export %s=your-key-here\n  claudemem setup\n\n", envVarName)
+		fmt.Fprintln(w, "Get a key at: https://platform.openai.com/api-keys")
+		return nil, fmt.Errorf("%s not set in environment", envVarName)
+	}
+	fmt.Fprintf(w, "Environment variable %s: set ✓\n", envVarName)
+
+	fmt.Fprintln(w, "\nWhich model?")
+	fmt.Fprintln(w, "  1) text-embedding-3-small   (recommended — $0.02/M, 512-dim matryoshka)")
+	fmt.Fprintln(w, "  2) text-embedding-3-large   (higher quality, $0.13/M, 3072-dim)")
+	choice, err := promptChoice(w, r, "> ", 2)
+	if err != nil {
+		return nil, err
+	}
+	var model string
+	var defaultDim int
+	switch choice {
+	case 1:
+		model = "text-embedding-3-small"
+		defaultDim = 512
+	case 2:
+		model = "text-embedding-3-large"
+		defaultDim = 1024
+	}
+
+	dim, err := promptDim(w, r, defaultDim)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprint(w, "Testing embedding ... ")
+	emb := vectors.NewOpenAIEmbedder(model, key, dim)
+	vec, err := emb.Embed("hello world", vectors.InputTypeDocument)
+	if err != nil {
+		fmt.Fprintln(w, "FAIL")
+		return nil, fmt.Errorf("openai test embed failed: %w", err)
+	}
+	fmt.Fprintf(w, "✓ got %d-dim vector\n", len(vec))
+
+	return &WizardResult{
+		Config: vectors.BackendConfig{
+			Backend: "openai",
 			Model:   model,
 			APIKey:  key,
 			Dim:     dim,

--- a/pkg/config/wizard.go
+++ b/pkg/config/wizard.go
@@ -1,0 +1,396 @@
+package config
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/zelinewang/claudemem/pkg/vectors"
+)
+
+// WizardOptions controls wizard I/O. Extracted so tests can drive the wizard
+// without stdin/stdout.
+type WizardOptions struct {
+	In       io.Reader // defaults to os.Stdin
+	Out      io.Writer // defaults to os.Stdout
+	StoreDir string    // ~/.claudemem
+	// SkipReindexPrompt: if true, caller handles reindex separately.
+	SkipReindexPrompt bool
+}
+
+// WizardResult describes what the wizard chose. The caller writes it to
+// the config file and optionally runs reindex.
+type WizardResult struct {
+	Config       vectors.BackendConfig
+	APIKeyEnvVar string // name of the env var for cloud; "" for local/tfidf
+	RunReindex   bool   // whether the user wants to rebuild the index now
+}
+
+// RunSetupWizard walks the user through picking + verifying a backend.
+// Returns the selected config. Does NOT write to disk — caller is
+// responsible for persistence (keeps the wizard pure + testable).
+func RunSetupWizard(opts WizardOptions) (*WizardResult, error) {
+	if opts.In == nil {
+		opts.In = os.Stdin
+	}
+	if opts.Out == nil {
+		opts.Out = os.Stdout
+	}
+	r := bufio.NewReader(opts.In)
+
+	banner(opts.Out)
+
+	fmt.Fprintln(opts.Out, "Which embedding backend do you want to use?")
+	fmt.Fprintln(opts.Out, "")
+	fmt.Fprintln(opts.Out, "  1) Local — Ollama         (offline, zero cost, recommended for daily use)")
+	fmt.Fprintln(opts.Out, "  2) Cloud — Gemini         (best quality, ~$0.15/M tokens, requires API key)")
+	fmt.Fprintln(opts.Out, "  3) Cloud — Voyage         (budget pick, $0.02/M, [not yet implemented, lands in P7])")
+	fmt.Fprintln(opts.Out, "  4) Cloud — OpenAI         (widely available, weaker Chinese, [not yet implemented, lands in P7])")
+	fmt.Fprintln(opts.Out, "  5) No semantic search     — TF-IDF (keyword-ish; no daemon/key needed)")
+	fmt.Fprintln(opts.Out, "")
+
+	choice, err := promptChoice(opts.Out, r, "> ", 5)
+	if err != nil {
+		return nil, err
+	}
+
+	switch choice {
+	case 1:
+		return setupOllama(opts.Out, r, opts.StoreDir)
+	case 2:
+		return setupGemini(opts.Out, r, opts.StoreDir)
+	case 3:
+		return nil, fmt.Errorf("voyage backend lands in P7 — pick another for now")
+	case 4:
+		return nil, fmt.Errorf("openai backend lands in P7 — pick another for now")
+	case 5:
+		return setupTFIDF(opts.Out, r)
+	}
+	return nil, fmt.Errorf("unexpected choice %d", choice)
+}
+
+// --- Ollama path ---
+
+func setupOllama(w io.Writer, r *bufio.Reader, storeDir string) (*WizardResult, error) {
+	const baseURL = "http://localhost:11434"
+	fmt.Fprintf(w, "Checking %s ... ", baseURL)
+	if err := pingOllama(baseURL); err != nil {
+		fmt.Fprintln(w, "unreachable")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "  Recovery:")
+		fmt.Fprintln(w, "    - Install Ollama: curl -fsSL https://ollama.com/install.sh | sh  (needs sudo)")
+		fmt.Fprintln(w, "    - Or user-local: see docs/HYBRID_EMBEDDING_PLAN.md Phase A")
+		fmt.Fprintln(w, "    - Then: ollama serve &")
+		return nil, fmt.Errorf("ollama daemon not reachable: %w", err)
+	}
+	fmt.Fprintln(w, "OK")
+	fmt.Fprintln(w, "")
+
+	models, err := listOllamaModels(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("list models: %w", err)
+	}
+
+	// Recommended top 3 + "other"
+	recommended := []string{
+		"qwen3-embedding:4b  (bilingual, 2.5GB, recommended)",
+		"bge-m3              (100+ languages, 1.2GB)",
+		"nomic-embed-text    (small, 270MB, English-heavy)",
+	}
+	fmt.Fprintln(w, "Which model?")
+	for i, m := range recommended {
+		status := "  "
+		if contains(models, trimModelLine(m)) {
+			status = "✓ " // already pulled
+		}
+		fmt.Fprintf(w, "  %d) %s%s\n", i+1, status, m)
+	}
+	fmt.Fprintln(w, "  4) Other (enter name)")
+	modelChoice, err := promptChoice(w, r, "> ", 4)
+	if err != nil {
+		return nil, err
+	}
+
+	var model string
+	switch modelChoice {
+	case 1:
+		model = "qwen3-embedding:4b"
+	case 2:
+		model = "bge-m3"
+	case 3:
+		model = "nomic-embed-text"
+	case 4:
+		model, err = promptLine(w, r, "Model name: ")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Offer to pull if missing
+	if !contains(models, model) {
+		fmt.Fprintf(w, "Model %q not installed locally. Pull now? [Y/n] ", model)
+		answer, _ := promptLine(w, r, "")
+		if strings.ToLower(strings.TrimSpace(answer)) != "n" {
+			fmt.Fprintf(w, "Run: ollama pull %s  (this may take a few minutes)\n", model)
+			fmt.Fprintln(w, "  (run this in another terminal; press Enter here once the pull completes)")
+			_, _ = promptLine(w, r, "")
+		}
+	}
+
+	dim, err := promptDim(w, r, 768)
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify with a test embedding
+	fmt.Fprint(w, "Testing embedding: \"hello world\" ... ")
+	emb := vectors.NewOllamaEmbedder(model)
+	vec, err := emb.Embed("hello world", vectors.InputTypeDocument)
+	if err != nil {
+		fmt.Fprintln(w, "FAIL")
+		return nil, fmt.Errorf("ollama test embed failed: %w", err)
+	}
+	actualDim := len(vec)
+	fmt.Fprintf(w, "✓ got %d-dim vector\n", actualDim)
+
+	// Honor matryoshka truncation request ONLY if backend supports it.
+	// Ollama doesn't natively truncate; warn if user asked for a smaller dim.
+	if dim > 0 && dim != actualDim {
+		fmt.Fprintf(w,
+			"⚠ Ollama produces %d-dim vectors; requested truncation to %d is not supported by the API.\n",
+			actualDim, dim)
+		fmt.Fprintln(w, "  Keeping native dim. (Matryoshka truncation works on Gemini/Voyage, not Ollama.)")
+		dim = actualDim
+	}
+	if dim == 0 {
+		dim = actualDim
+	}
+
+	return &WizardResult{
+		Config: vectors.BackendConfig{
+			Backend: "ollama",
+			Model:   model,
+			Dim:     dim,
+		},
+		RunReindex: confirmReindex(w, r),
+	}, nil
+}
+
+// --- Gemini path ---
+
+func setupGemini(w io.Writer, r *bufio.Reader, storeDir string) (*WizardResult, error) {
+	const envVarName = "GEMINI_API_KEY"
+	key := os.Getenv(envVarName)
+	if key == "" {
+		fmt.Fprintf(w, "\nEnvironment variable %s is NOT set.\n", envVarName)
+		fmt.Fprintln(w, "claudemem never stores API keys in config files. Set the env var and re-run.")
+		fmt.Fprintf(w, "\n  export %s=your-key-here\n  claudemem setup\n\n", envVarName)
+		fmt.Fprintln(w, "Get a key at: https://aistudio.google.com/app/apikey")
+		return nil, fmt.Errorf("%s not set in environment", envVarName)
+	}
+	fmt.Fprintf(w, "Environment variable %s: set ✓\n", envVarName)
+
+	fmt.Fprintln(w, "\nWhich model?")
+	fmt.Fprintln(w, "  1) gemini-embedding-001  (recommended — MTEB #1 multilingual, 3072→768-dim matryoshka)")
+	modelChoice, err := promptChoice(w, r, "> ", 1)
+	if err != nil {
+		return nil, err
+	}
+	model := "gemini-embedding-001"
+	_ = modelChoice
+
+	dim, err := promptDim(w, r, 768)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Fprint(w, "Testing embedding ... ")
+	emb := vectors.NewGeminiEmbedder(model, key, dim)
+	vec, err := emb.Embed("hello world", vectors.InputTypeDocument)
+	if err != nil {
+		fmt.Fprintln(w, "FAIL")
+		return nil, fmt.Errorf("gemini test embed failed: %w", err)
+	}
+	fmt.Fprintf(w, "✓ got %d-dim vector\n", len(vec))
+
+	return &WizardResult{
+		Config: vectors.BackendConfig{
+			Backend: "gemini",
+			Model:   model,
+			APIKey:  key,
+			Dim:     dim,
+		},
+		APIKeyEnvVar: envVarName,
+		RunReindex:   confirmReindex(w, r),
+	}, nil
+}
+
+// --- TF-IDF path ---
+
+func setupTFIDF(w io.Writer, r *bufio.Reader) (*WizardResult, error) {
+	fmt.Fprintln(w, "\nSelected: TF-IDF (keyword similarity, no external dependency).")
+	fmt.Fprintln(w, "Semantic search will work on vocabulary from your indexed corpus only.")
+	return &WizardResult{
+		Config: vectors.BackendConfig{
+			Backend: "tfidf",
+			Model:   "tfidf",
+		},
+		RunReindex: confirmReindex(w, r),
+	}, nil
+}
+
+// --- helpers ---
+
+func banner(w io.Writer) {
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "claudemem — Memory Setup")
+	fmt.Fprintln(w, "")
+}
+
+func pingOllama(baseURL string) error {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(baseURL + "/api/tags")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func listOllamaModels(baseURL string) ([]string, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(baseURL + "/api/tags")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Models []struct {
+			Name string `json:"name"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	names := make([]string, len(body.Models))
+	for i, m := range body.Models {
+		names[i] = m.Name
+	}
+	return names, nil
+}
+
+// promptChoice reads "N" from the reader, validating 1..max.
+func promptChoice(w io.Writer, r *bufio.Reader, prompt string, max int) (int, error) {
+	for {
+		fmt.Fprint(w, prompt)
+		line, err := r.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return 0, err
+		}
+		line = strings.TrimSpace(line)
+		n, convErr := strconv.Atoi(line)
+		if convErr != nil || n < 1 || n > max {
+			fmt.Fprintf(w, "  Please enter a number 1..%d\n", max)
+			continue
+		}
+		return n, nil
+	}
+}
+
+func promptLine(w io.Writer, r *bufio.Reader, prompt string) (string, error) {
+	fmt.Fprint(w, prompt)
+	line, err := r.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
+}
+
+func promptDim(w io.Writer, r *bufio.Reader, defaultDim int) (int, error) {
+	fmt.Fprintf(w, "Matryoshka dimension (recommended %d for <5k notes) [%d]: ", defaultDim, defaultDim)
+	line, err := promptLine(w, r, "")
+	if err != nil {
+		return 0, err
+	}
+	if line == "" {
+		return defaultDim, nil
+	}
+	n, err := strconv.Atoi(line)
+	if err != nil || n < 1 {
+		fmt.Fprintf(w, "  Invalid dim; keeping default %d\n", defaultDim)
+		return defaultDim, nil
+	}
+	return n, nil
+}
+
+func confirmReindex(w io.Writer, r *bufio.Reader) bool {
+	fmt.Fprint(w, "\nRebuild vector index with new backend now? [Y/n] ")
+	answer, _ := promptLine(w, r, "")
+	return strings.ToLower(answer) != "n"
+}
+
+// trimModelLine extracts the model name from a "name  (description)" line.
+func trimModelLine(s string) string {
+	if i := strings.Index(s, " "); i > 0 {
+		return strings.TrimSpace(s[:i])
+	}
+	return s
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, h := range haystack {
+		// Ollama returns "qwen3-embedding:4b" or "nomic-embed-text:latest"
+		if h == needle || strings.HasPrefix(h, needle+":") {
+			return true
+		}
+	}
+	return false
+}
+
+// --- config persistence helpers for the CLI layer ---
+
+// ApplyBackendToConfig writes the wizard result to ~/.claudemem/config.json.
+// Secrets (API keys) are NEVER written — only the env var NAME.
+func ApplyBackendToConfig(storeDir string, result *WizardResult) error {
+	cfg, err := Load(storeDir)
+	if err != nil {
+		return err
+	}
+	cfg.Set("embedding.backend", result.Config.Backend)
+	cfg.Set("embedding.model", result.Config.Model)
+	if result.Config.Dim > 0 {
+		cfg.Set("embedding.dimensions", result.Config.Dim)
+	}
+	if result.Config.Endpoint != "" {
+		cfg.Set("embedding.endpoint", result.Config.Endpoint)
+	}
+	if result.APIKeyEnvVar != "" {
+		cfg.Set("embedding.api_key_env", result.APIKeyEnvVar)
+	}
+	// Reconfirm feature flag
+	cfg.Set("features.semantic_search", "true")
+	return cfg.Save()
+}
+
+// IsSecretKey reports whether a config key name looks like a place someone
+// might mistakenly try to store an API key. The CLI `config set` command
+// rejects these to enforce env-var-only secrets.
+func IsSecretKey(key string) bool {
+	k := strings.ToLower(key)
+	if strings.Contains(k, "api_key_env") {
+		return false // that's the env var NAME, safe to store
+	}
+	return strings.Contains(k, "api_key") ||
+		strings.Contains(k, "secret") ||
+		strings.Contains(k, "password") ||
+		strings.Contains(k, "token")
+}

--- a/pkg/config/wizard_test.go
+++ b/pkg/config/wizard_test.go
@@ -1,0 +1,143 @@
+package config
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestWizard_TFIDFPath walks through the simplest happy path: user picks
+// TF-IDF (no network, no keys) and declines the auto-reindex.
+func TestWizard_TFIDFPath(t *testing.T) {
+	// Input script: "5\n" (pick TF-IDF) → "n\n" (decline reindex)
+	in := bytes.NewBufferString("5\nn\n")
+	out := &bytes.Buffer{}
+
+	result, err := RunSetupWizard(WizardOptions{In: in, Out: out})
+	if err != nil {
+		t.Fatalf("wizard error: %v\noutput: %s", err, out.String())
+	}
+	if result.Config.Backend != "tfidf" {
+		t.Errorf("expected backend=tfidf, got %q", result.Config.Backend)
+	}
+	if result.RunReindex {
+		t.Errorf("user declined reindex but RunReindex=true")
+	}
+}
+
+// TestWizard_TFIDFPath_ReindexAccepted verifies the default-yes reindex prompt.
+func TestWizard_TFIDFPath_ReindexAccepted(t *testing.T) {
+	// "5\n" pick TF-IDF; "\n" (empty = accept default Y)
+	in := bytes.NewBufferString("5\n\n")
+	out := &bytes.Buffer{}
+
+	result, err := RunSetupWizard(WizardOptions{In: in, Out: out})
+	if err != nil {
+		t.Fatalf("wizard error: %v", err)
+	}
+	if !result.RunReindex {
+		t.Errorf("default should be yes-reindex (got false)")
+	}
+}
+
+// TestWizard_RejectsVoyageStub verifies P7-deferred backends return a
+// helpful error rather than a crash.
+func TestWizard_RejectsVoyageStub(t *testing.T) {
+	in := bytes.NewBufferString("3\n")
+	out := &bytes.Buffer{}
+
+	_, err := RunSetupWizard(WizardOptions{In: in, Out: out})
+	if err == nil || !strings.Contains(err.Error(), "voyage") {
+		t.Errorf("expected voyage-not-implemented error, got: %v", err)
+	}
+}
+
+// TestWizard_InvalidChoice loops until a valid option is provided,
+// and the loop MUST consume invalid input (not crash on 0, 99, letters).
+func TestWizard_InvalidChoice(t *testing.T) {
+	// "0\nfoo\n99\n5\nn\n" — three invalid then pick TF-IDF + decline reindex
+	in := bytes.NewBufferString("0\nfoo\n99\n5\nn\n")
+	out := &bytes.Buffer{}
+
+	result, err := RunSetupWizard(WizardOptions{In: in, Out: out})
+	if err != nil {
+		t.Fatalf("wizard error: %v", err)
+	}
+	if result.Config.Backend != "tfidf" {
+		t.Errorf("expected backend=tfidf after retries, got %q", result.Config.Backend)
+	}
+	// Output should contain the "please enter 1..5" guidance
+	if !strings.Contains(out.String(), "Please enter a number 1..5") {
+		t.Errorf("output missing retry guidance; got: %s", out.String())
+	}
+}
+
+// TestIsSecretKey guards against the "copy-pasted curl with API key" footgun.
+// Ensure known secret-ish names are rejected, but the env-var-name key is ok.
+func TestIsSecretKey(t *testing.T) {
+	cases := []struct {
+		key    string
+		secret bool
+	}{
+		{"embedding.api_key", true},
+		{"embedding.api_key_env", false}, // storing env var NAME is fine
+		{"gemini_api_key", true},
+		{"openai_api_key", true},
+		{"voyage_api_key", true},
+		{"some.password", true},
+		{"oauth_secret", true},
+		{"auth.token", true},
+		{"embedding.backend", false},
+		{"embedding.model", false},
+		{"embedding.endpoint", false},
+		{"features.semantic_search", false},
+	}
+	for _, tc := range cases {
+		got := IsSecretKey(tc.key)
+		if got != tc.secret {
+			t.Errorf("IsSecretKey(%q): want %v, got %v", tc.key, tc.secret, got)
+		}
+	}
+}
+
+// TestApplyBackendToConfig confirms WizardResult lands in the right config keys
+// AND that the API key itself never touches disk.
+func TestApplyBackendToConfig(t *testing.T) {
+	dir := t.TempDir()
+	result := &WizardResult{
+		APIKeyEnvVar: "GEMINI_API_KEY",
+	}
+	result.Config.Backend = "gemini"
+	result.Config.Model = "gemini-embedding-001"
+	result.Config.Dim = 768
+	result.Config.APIKey = "THIS-SHOULD-NEVER-BE-WRITTEN"
+
+	if err := ApplyBackendToConfig(dir, result); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// Reload and verify
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if cfg.GetString("embedding.backend") != "gemini" {
+		t.Errorf("backend: want gemini, got %q", cfg.GetString("embedding.backend"))
+	}
+	if cfg.GetString("embedding.model") != "gemini-embedding-001" {
+		t.Errorf("model wrong: %q", cfg.GetString("embedding.model"))
+	}
+	if cfg.GetInt("embedding.dimensions") != 768 {
+		t.Errorf("dim wrong: %d", cfg.GetInt("embedding.dimensions"))
+	}
+	if cfg.GetString("embedding.api_key_env") != "GEMINI_API_KEY" {
+		t.Errorf("env var name not recorded")
+	}
+	// CRITICAL: the raw key must NOT be in config
+	for _, key := range cfg.Keys() {
+		v := cfg.GetString(key)
+		if strings.Contains(v, "THIS-SHOULD-NEVER-BE-WRITTEN") {
+			t.Fatalf("API key leaked into config key %q", key)
+		}
+	}
+}

--- a/pkg/config/wizard_test.go
+++ b/pkg/config/wizard_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 )
@@ -40,15 +41,24 @@ func TestWizard_TFIDFPath_ReindexAccepted(t *testing.T) {
 	}
 }
 
-// TestWizard_RejectsVoyageStub verifies P7-deferred backends return a
-// helpful error rather than a crash.
-func TestWizard_RejectsVoyageStub(t *testing.T) {
+// TestWizard_VoyageRequiresAPIKey checks that selecting Voyage without
+// VOYAGE_API_KEY set aborts with a clear message pointing to the env var.
+// This is the "don't store secrets in config" rule manifest at the UX layer.
+func TestWizard_VoyageRequiresAPIKey(t *testing.T) {
+	// Ensure the env var is NOT set for this test
+	orig := os.Getenv("VOYAGE_API_KEY")
+	os.Unsetenv("VOYAGE_API_KEY")
+	defer os.Setenv("VOYAGE_API_KEY", orig)
+
 	in := bytes.NewBufferString("3\n")
 	out := &bytes.Buffer{}
 
 	_, err := RunSetupWizard(WizardOptions{In: in, Out: out})
-	if err == nil || !strings.Contains(err.Error(), "voyage") {
-		t.Errorf("expected voyage-not-implemented error, got: %v", err)
+	if err == nil || !strings.Contains(err.Error(), "VOYAGE_API_KEY") {
+		t.Errorf("expected VOYAGE_API_KEY-not-set error, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "dash.voyageai.com/api-keys") {
+		t.Errorf("expected key signup URL in output, got: %s", out.String())
 	}
 }
 

--- a/pkg/storage/filestore.go
+++ b/pkg/storage/filestore.go
@@ -120,5 +120,27 @@ func (fs *FileStore) Close() error {
 	return nil
 }
 
+// DB returns the underlying *sql.DB for use by health / repair tools that
+// need to run custom queries without threading them through FileStore.
+// Kept intentionally read-write so the repair command can DELETE orphan
+// rows directly — but callers SHOULD prefer FileStore methods when one exists.
+func (fs *FileStore) DB() *sql.DB { return fs.db }
+
+// NotesDir returns the filesystem path where markdown notes live.
+func (fs *FileStore) NotesDir() string { return fs.notesDir }
+
+// SessionsDir returns the filesystem path where session reports live.
+func (fs *FileStore) SessionsDir() string { return fs.sessionsDir }
+
+// VectorStoreEmbedder returns the active Embedder, or nil if semantic
+// search is not configured. Used by health/repair to know which
+// (backend, model) tuple to validate for invariant I3.
+func (fs *FileStore) VectorStoreEmbedder() vectors.Embedder {
+	if fs.vectorStore == nil {
+		return nil
+	}
+	return fs.vectorStore.Embedder()
+}
+
 // UnifiedStore methods (Note/Session methods implemented in filestore_notes.go and filestore_sessions.go)
 // Search and Stats methods are implemented in filestore_search.go and filestore_stats.go

--- a/pkg/storage/filestore_vectors.go
+++ b/pkg/storage/filestore_vectors.go
@@ -200,9 +200,19 @@ func (fs *FileStore) HybridSearch(query string, opts SearchOpts) ([]SearchResult
 		return ftsResults, nil
 	}
 
-	// Get semantic results
+	// Get semantic results. CRITICAL: when the configured embedding backend
+	// is unreachable, SemanticSearch returns ErrBackendUnavailable. We MUST
+	// propagate that to the caller — otherwise the fail-loud UX in
+	// cmd/search.go never triggers and we silently degrade to FTS-only,
+	// violating the "no silent fallback" design rule.
+	//
+	// For all OTHER errors (e.g. transient DB read issues), keep the old
+	// forgiving behavior so hybrid search stays useful.
 	semanticResults, err := fs.SemanticSearch(query, opts.Limit)
 	if err != nil {
+		if vectors.IsBackendUnavailable(err) {
+			return nil, err
+		}
 		return ftsResults, nil
 	}
 

--- a/pkg/storage/filestore_vectors.go
+++ b/pkg/storage/filestore_vectors.go
@@ -6,23 +6,67 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/zelinewang/claudemem/pkg/config"
 	"github.com/zelinewang/claudemem/pkg/vectors"
 )
 
-// InitVectorStore initializes the vector store for semantic search.
-// This should be called after NewFileStore when the feature is enabled.
+// InitVectorStore initializes the vector store for semantic search using
+// the configured embedding backend. Config keys consulted:
+//
+//	embedding.backend       (default: "tfidf" on fresh install)
+//	embedding.model         (backend-specific default)
+//	embedding.dimensions    (matryoshka truncation; 0 = native)
+//	embedding.endpoint      (optional URL override, e.g., Ollama on a remote host)
+//	embedding.api_key_env   (name of the env var holding the API key for cloud)
+//
+// For P1 this only supports Ollama and TF-IDF; Gemini/Voyage/OpenAI land in
+// later phases. The backend is constructed but NOT pinged here — availability
+// is checked at use time so write-path ops stay forgiving and read-path ops
+// can surface the error with recovery instructions (P4).
 func (fs *FileStore) InitVectorStore() error {
 	if fs.db == nil {
 		return fmt.Errorf("database not initialized")
 	}
 
-	vs, err := vectors.NewVectorStore(fs.db)
+	bc, err := loadBackendConfig(fs.baseDir)
+	if err != nil {
+		return fmt.Errorf("load embedding config: %w", err)
+	}
+	embedder, err := vectors.BuildEmbedder(bc)
+	if err != nil {
+		return fmt.Errorf("build embedder (%s:%s): %w — run `claudemem setup` to fix",
+			bc.Backend, bc.Model, err)
+	}
+
+	vs, err := vectors.NewVectorStore(fs.db, embedder)
 	if err != nil {
 		return fmt.Errorf("failed to initialize vector store: %w", err)
 	}
-
 	fs.vectorStore = vs
 	return nil
+}
+
+// loadBackendConfig reads embedding.* keys from ~/.claudemem/config.json
+// and resolves the API key from the named env var (never stored on disk).
+func loadBackendConfig(storeDir string) (vectors.BackendConfig, error) {
+	cfg, err := config.Load(storeDir)
+	if err != nil {
+		return vectors.BackendConfig{}, err
+	}
+	backend := cfg.GetString("embedding.backend")
+	if backend == "" {
+		backend = "tfidf" // first-run default; user can upgrade via `claudemem setup`
+	}
+	bc := vectors.BackendConfig{
+		Backend:  backend,
+		Model:    cfg.GetString("embedding.model"),
+		Endpoint: cfg.GetString("embedding.endpoint"),
+		Dim:      cfg.GetInt("embedding.dimensions"),
+	}
+	if keyEnv := cfg.GetString("embedding.api_key_env"); keyEnv != "" {
+		bc.APIKey = os.Getenv(keyEnv)
+	}
+	return bc, nil
 }
 
 // HasVectorStore returns true if semantic search is initialized.

--- a/pkg/sync/gitsync.go
+++ b/pkg/sync/gitsync.go
@@ -1,0 +1,237 @@
+// Package sync implements markdown-only git sync for claudemem memory
+// across machines. Only notes/ + sessions/ ship over the wire; SQLite
+// index and config.json stay per-machine. Each machine rebuilds its own
+// FTS and embeds missing vectors under its configured backend on pull.
+//
+// This decouples memory content (shared) from search infrastructure
+// (per-machine). Two machines can run different embedding backends
+// against the same corpus and still share notes.
+package sync
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// GitSync wraps the git CLI at a single claudemem store directory.
+// We shell out rather than depend on libgit2 because (a) git CLI is
+// universally available on dev machines, (b) claudemem's small Go
+// binary footprint stays small, (c) users already understand git
+// error messages when things go wrong.
+type GitSync struct {
+	Dir string // ~/.claudemem
+}
+
+// NewGitSync returns a GitSync rooted at dir.
+func NewGitSync(dir string) *GitSync { return &GitSync{Dir: dir} }
+
+// IsInitialized reports whether Dir is already a git repo.
+func (g *GitSync) IsInitialized() bool {
+	_, err := os.Stat(filepath.Join(g.Dir, ".git"))
+	return err == nil
+}
+
+// Init creates .git, writes .gitignore, and sets the remote. Does NOT
+// create an initial commit — the caller should add markdown + commit
+// explicitly so the user sees what is about to be pushed.
+func (g *GitSync) Init(remoteURL string) error {
+	if g.IsInitialized() {
+		return fmt.Errorf("%s is already a git repo; use `sync status` to inspect", g.Dir)
+	}
+	// `-b main` works on git 2.28+; symbolic-ref fallback handles older git
+	// that doesn't recognize -b.
+	if err := g.git("init", "-b", "main"); err != nil {
+		if err2 := g.git("init"); err2 != nil {
+			return fmt.Errorf("git init: %w", err2)
+		}
+		_ = g.git("symbolic-ref", "HEAD", "refs/heads/main")
+	}
+
+	if err := g.writeGitignore(); err != nil {
+		return fmt.Errorf("write .gitignore: %w", err)
+	}
+
+	if remoteURL != "" {
+		if err := g.git("remote", "add", "origin", remoteURL); err != nil {
+			return fmt.Errorf("add remote: %w", err)
+		}
+	}
+	return nil
+}
+
+// writeGitignore installs the canonical ignore rules. Keeps ~/.claudemem
+// safe to push even if the user accidentally runs commands that scribble
+// state into unexpected paths.
+//
+// What is gitignored:
+//   .index/              — SQLite DB; per-machine, rebuildable from markdown
+//   config.json          — per-machine embedding backend choice
+//   .sync_auto_pull      — per-machine auto-sync toggle
+//   .sync_auto_push      — per-machine auto-sync toggle
+//   .bak, .tmp, .swp     — editor temp files
+func (g *GitSync) writeGitignore() error {
+	content := `# claudemem memory sync — per-machine files excluded
+.index/
+config.json
+.sync_auto_pull
+.sync_auto_push
+
+# editor / OS temp files
+*.bak
+*.tmp
+*.swp
+.DS_Store
+`
+	return os.WriteFile(filepath.Join(g.Dir, ".gitignore"), []byte(content), 0644)
+}
+
+// Status returns the output of `git status --short`.
+func (g *GitSync) Status() (string, error) {
+	return g.gitOutput("status", "--short")
+}
+
+// RemoteURL returns the origin push URL, or "" if no remote configured.
+func (g *GitSync) RemoteURL() string {
+	out, err := g.gitOutput("remote", "get-url", "origin")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
+// Push stages every tracked + new markdown file under notes/ and sessions/
+// plus MEMORY.md if present, commits with a descriptive message, and
+// pushes to origin. Silent on no-op (no changes to commit).
+func (g *GitSync) Push(message string) error {
+	if !g.IsInitialized() {
+		return fmt.Errorf("not a git repo; run `claudemem sync init <remote>` first")
+	}
+	// Stage ONLY the content paths that actually exist. git add with
+	// multiple pathspecs treats a missing one as a hard error which
+	// prevents the OTHER paths from being staged — so iterate per-path.
+	for _, p := range []string{"notes/", "sessions/", "MEMORY.md", ".gitignore"} {
+		if _, err := os.Stat(filepath.Join(g.Dir, p)); err != nil {
+			continue // not present — skip
+		}
+		if err := g.git("add", p); err != nil {
+			return fmt.Errorf("git add %s: %w", p, err)
+		}
+	}
+
+	// Check if anything is actually staged. `git diff --cached --quiet`
+	// exits 0 when nothing is staged, 1 when there are staged changes.
+	// We use that exit code rather than trying to parse the generic
+	// "exit status 1" we get back from the commit command.
+	hasChanges := g.hasStagedChanges()
+	if hasChanges {
+		msg := message
+		if msg == "" {
+			msg = "memory: sync from " + hostname()
+		}
+		if err := g.git("commit", "-m", msg); err != nil {
+			return fmt.Errorf("git commit: %w", err)
+		}
+	}
+
+	if g.RemoteURL() == "" {
+		return fmt.Errorf("no remote configured; run `git remote add origin <url>` inside %s", g.Dir)
+	}
+
+	// If nothing was committed AND local is already up-to-date with remote,
+	// skip the push — avoids a noisy "Everything up-to-date" on every hook.
+	if !hasChanges {
+		if g.localAheadOfRemote() {
+			// local has unpushed commits from a previous session; push them
+		} else {
+			return nil // nothing to do
+		}
+	}
+
+	if err := g.git("push", "-u", "origin", "HEAD"); err != nil {
+		return fmt.Errorf("git push: %w", err)
+	}
+	return nil
+}
+
+// hasStagedChanges reports whether `git commit` would produce a new
+// commit. Uses `diff --cached --quiet` whose exit code is 0=clean, 1=dirty.
+func (g *GitSync) hasStagedChanges() bool {
+	cmd := exec.Command("git", "diff", "--cached", "--quiet")
+	cmd.Dir = g.Dir
+	err := cmd.Run()
+	// Run() returns *ExitError with ExitCode()==1 when there ARE changes.
+	if err == nil {
+		return false
+	}
+	if ee, ok := err.(*exec.ExitError); ok && ee.ExitCode() == 1 {
+		return true
+	}
+	// Any other error (e.g., git not found) — treat as "don't commit".
+	return false
+}
+
+// localAheadOfRemote reports whether HEAD has commits not yet on origin.
+// Best-effort: returns false on any error (new branch with no upstream,
+// network issues, etc.) so the caller doesn't push blindly.
+func (g *GitSync) localAheadOfRemote() bool {
+	cmd := exec.Command("git", "rev-list", "--count", "@{u}..HEAD")
+	cmd.Dir = g.Dir
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) != "0"
+}
+
+// Pull runs `git pull --ff-only` to avoid accidental merge commits
+// inside the memory repo. If fast-forward fails, returns an error
+// suggesting manual resolution — we don't automate merge of markdown
+// because timestamps + session_id make auto-merges unsafe.
+func (g *GitSync) Pull() error {
+	if !g.IsInitialized() {
+		return fmt.Errorf("not a git repo; run `claudemem sync init <remote>` first")
+	}
+	if err := g.git("pull", "--ff-only", "origin", "HEAD"); err != nil {
+		return fmt.Errorf("git pull: %w (resolve manually in %s, then re-run)", err, g.Dir)
+	}
+	return nil
+}
+
+// --- internal helpers ---
+
+func (g *GitSync) git(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = g.Dir
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (g *GitSync) gitOutput(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = g.Dir
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// gitMaybe is `git <args>` but tolerates "no files matched" errors that
+// happen when notes/ or MEMORY.md doesn't exist yet.
+func (g *GitSync) gitMaybe(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = g.Dir
+	out, err := cmd.CombinedOutput()
+	if err != nil && !strings.Contains(string(out), "did not match any files") {
+		return fmt.Errorf("%s: %s", strings.Join(args, " "), string(out))
+	}
+	return nil
+}
+
+func hostname() string {
+	h, err := os.Hostname()
+	if err != nil {
+		return "unknown"
+	}
+	return h
+}

--- a/pkg/sync/gitsync.go
+++ b/pkg/sync/gitsync.go
@@ -38,6 +38,12 @@ func (g *GitSync) IsInitialized() bool {
 // create an initial commit — the caller should add markdown + commit
 // explicitly so the user sees what is about to be pushed.
 func (g *GitSync) Init(remoteURL string) error {
+	// First-run safety: the ~/.claudemem dir may not exist yet on a fresh
+	// install. `git init` refuses to create its parent; fail here with a
+	// useful message rather than the cryptic git error.
+	if err := os.MkdirAll(g.Dir, 0700); err != nil {
+		return fmt.Errorf("create %s: %w", g.Dir, err)
+	}
 	if g.IsInitialized() {
 		return fmt.Errorf("%s is already a git repo; use `sync status` to inspect", g.Dir)
 	}

--- a/pkg/sync/gitsync.go
+++ b/pkg/sync/gitsync.go
@@ -208,11 +208,24 @@ func (g *GitSync) Pull() error {
 
 // --- internal helpers ---
 
+// git runs `git <args>` in g.Dir and surfaces stderr+stdout in the error
+// message when the command fails. Hook contexts (SessionEnd) often
+// suppress stderr, so wrapping the full output into the returned error
+// is the only way users see "fatal: refusing to merge unrelated
+// histories" or similar actionable git messages.
 func (g *GitSync) git(args ...string) error {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = g.Dir
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		// Trim trailing newlines from git's output for cleaner error format.
+		msg := strings.TrimRight(string(out), "\n")
+		if msg == "" {
+			return err
+		}
+		return fmt.Errorf("%w\n%s", err, msg)
+	}
+	return nil
 }
 
 func (g *GitSync) gitOutput(args ...string) (string, error) {
@@ -222,17 +235,8 @@ func (g *GitSync) gitOutput(args ...string) (string, error) {
 	return string(out), err
 }
 
-// gitMaybe is `git <args>` but tolerates "no files matched" errors that
-// happen when notes/ or MEMORY.md doesn't exist yet.
-func (g *GitSync) gitMaybe(args ...string) error {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = g.Dir
-	out, err := cmd.CombinedOutput()
-	if err != nil && !strings.Contains(string(out), "did not match any files") {
-		return fmt.Errorf("%s: %s", strings.Join(args, " "), string(out))
-	}
-	return nil
-}
+// (gitMaybe removed — Push now per-path stats each target before adding,
+// which makes "missing file" tolerance unnecessary.)
 
 func hostname() string {
 	h, err := os.Hostname()

--- a/pkg/sync/gitsync_test.go
+++ b/pkg/sync/gitsync_test.go
@@ -1,0 +1,149 @@
+package sync
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// requireGit skips the test if git is not on PATH. Keeps CI from failing
+// on minimal containers without git installed.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed on this system")
+	}
+}
+
+// setupLocalBare creates a bare git repo in a temp dir to act as the
+// "remote" for the round-trip test. Returns its path.
+func setupLocalBare(t *testing.T) string {
+	t.Helper()
+	bare := t.TempDir()
+	cmd := exec.Command("git", "init", "--bare", "-b", "main", bare)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create bare: %v\n%s", err, string(out))
+	}
+	return bare
+}
+
+// setGitUser configures a temp user so commits work without global
+// git config. Required in CI and fresh containers.
+func setGitUser(t *testing.T, dir string) {
+	t.Helper()
+	for _, cmd := range [][]string{
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+	} {
+		c := exec.Command("git", cmd...)
+		c.Dir = dir
+		if out, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", cmd, err, string(out))
+		}
+	}
+}
+
+// TestGitSync_InitAndPush_RoundTrip exercises the full flow:
+//  1. Machine A `claudemem sync init` + seeds a note + push
+//  2. Machine B init against same bare repo + pull
+//  3. The note from Machine A is present on Machine B
+//
+// This is the smoke test for the whole cross-machine sync design.
+func TestGitSync_InitAndPush_RoundTrip(t *testing.T) {
+	requireGit(t)
+	remote := setupLocalBare(t)
+
+	// --- Machine A ---
+	dirA := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dirA, "notes", "test"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	note := filepath.Join(dirA, "notes", "test", "hello.md")
+	if err := os.WriteFile(note, []byte("# Hello from A\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	gA := NewGitSync(dirA)
+	if err := gA.Init(remote); err != nil {
+		t.Fatalf("A init: %v", err)
+	}
+	setGitUser(t, dirA)
+	if err := gA.Push("seed from A"); err != nil {
+		t.Fatalf("A push: %v", err)
+	}
+
+	// --- Machine B ---
+	dirB := t.TempDir()
+	// Simulate clone via init + remote + pull — matches the command users run
+	gB := NewGitSync(dirB)
+	cmd := exec.Command("git", "clone", remote, dirB)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("clone B: %v\n%s", err, string(out))
+	}
+	setGitUser(t, dirB)
+
+	// Check hello.md arrived
+	receivedPath := filepath.Join(dirB, "notes", "test", "hello.md")
+	data, err := os.ReadFile(receivedPath)
+	if err != nil {
+		t.Fatalf("B missing hello.md: %v", err)
+	}
+	if !strings.Contains(string(data), "Hello from A") {
+		t.Errorf("wrong content on B: %s", string(data))
+	}
+
+	// Test that .gitignore was pushed too
+	gitignore := filepath.Join(dirB, ".gitignore")
+	if data, err := os.ReadFile(gitignore); err != nil {
+		t.Errorf(".gitignore missing on B: %v", err)
+	} else if !strings.Contains(string(data), ".index/") {
+		t.Errorf(".gitignore lacks .index/ rule: %s", data)
+	}
+
+	// Verify B sees the remote URL
+	if gB.RemoteURL() == "" {
+		t.Error("B's remote URL is empty after clone")
+	}
+}
+
+// TestGitSync_Init_AlreadyInitialized verifies we don't clobber an
+// existing .git directory.
+func TestGitSync_Init_AlreadyInitialized(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	exec.Command("git", "-C", dir, "init").Run()
+	g := NewGitSync(dir)
+	err := g.Init("")
+	if err == nil || !strings.Contains(err.Error(), "already") {
+		t.Errorf("expected 'already a git repo' error, got: %v", err)
+	}
+}
+
+// TestGitSync_GitignoreExcludesStateFiles is a direct assertion on the
+// gitignore content because a broken rule here could leak config.json
+// (no secrets currently; env-var rule means API keys live OUT of config
+// — but config.json may contain per-machine tokens in the future).
+func TestGitSync_GitignoreExcludesStateFiles(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	g := NewGitSync(dir)
+	if err := g.Init(""); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, mustExclude := range []string{
+		".index/",
+		"config.json",
+		".sync_auto_pull",
+		".sync_auto_push",
+	} {
+		if !strings.Contains(string(data), mustExclude) {
+			t.Errorf(".gitignore missing rule for %q", mustExclude)
+		}
+	}
+}

--- a/pkg/vectors/cloud_providers_test.go
+++ b/pkg/vectors/cloud_providers_test.go
@@ -1,0 +1,187 @@
+package vectors
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestVoyage_Embed_RoundTrip verifies request shape + response parsing
+// against a mocked Voyage endpoint.
+func TestVoyage_Embed_RoundTrip(t *testing.T) {
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-voyage-key" {
+			t.Errorf("missing auth header; got %q", r.Header.Get("Authorization"))
+			http.Error(w, "no auth", 401)
+			return
+		}
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		seenBody = buf[:n]
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"embedding":[0.1,0.2,0.3,0.4],"index":0}]}`))
+	}))
+	defer srv.Close()
+
+	emb := NewVoyageEmbedder("voyage-3.5-lite", "test-voyage-key", 1024).WithBaseURL(srv.URL)
+	vec, err := emb.Embed("hello", InputTypeDocument)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vec) != 4 {
+		t.Errorf("want 4-dim vector, got %d", len(vec))
+	}
+
+	var req map[string]interface{}
+	json.Unmarshal(seenBody, &req)
+	if req["model"] != "voyage-3.5-lite" {
+		t.Errorf("model wrong: %v", req["model"])
+	}
+	if req["input_type"] != "document" {
+		t.Errorf("expected input_type=document, got %v", req["input_type"])
+	}
+	if dim, _ := req["output_dimension"].(float64); int(dim) != 1024 {
+		t.Errorf("expected output_dimension=1024, got %v", req["output_dimension"])
+	}
+}
+
+// TestVoyage_InputTypeQuery confirms query mode is serialized correctly —
+// matters for retrieval quality on Voyage (asymmetric model).
+func TestVoyage_InputTypeQuery(t *testing.T) {
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		seenBody = buf[:n]
+		w.Write([]byte(`{"data":[{"embedding":[0.5],"index":0}]}`))
+	}))
+	defer srv.Close()
+
+	emb := NewVoyageEmbedder("voyage-3.5-lite", "k", 1024).WithBaseURL(srv.URL)
+	_, _ = emb.Embed("search query", InputTypeQuery)
+
+	if !strings.Contains(string(seenBody), `"input_type":"query"`) {
+		t.Errorf("expected input_type=query, got body: %s", string(seenBody))
+	}
+}
+
+// TestVoyage_Batch_RespectsChunking exercises the 128-per-batch ceiling.
+// 300 inputs should chunk into 3 calls (128+128+44).
+func TestVoyage_Batch_RespectsChunking(t *testing.T) {
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		var req voyageRequest
+		buf := make([]byte, 1<<20)
+		n, _ := r.Body.Read(buf)
+		json.Unmarshal(buf[:n], &req)
+		// Echo back one 2-dim vector per input, with correct indices
+		data := make([]map[string]interface{}, len(req.Input))
+		for i := range req.Input {
+			data[i] = map[string]interface{}{
+				"embedding": []float32{float32(i), 0.5},
+				"index":     i,
+			}
+		}
+		resp, _ := json.Marshal(map[string]interface{}{"data": data})
+		w.Write(resp)
+	}))
+	defer srv.Close()
+
+	texts := make([]string, 300)
+	for i := range texts {
+		texts[i] = "text"
+	}
+	emb := NewVoyageEmbedder("voyage-3.5-lite", "k", 0).WithBaseURL(srv.URL)
+	vecs, err := emb.EmbedBatch(texts, InputTypeDocument)
+	if err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+	if len(vecs) != 300 {
+		t.Errorf("want 300 vectors, got %d", len(vecs))
+	}
+	if callCount != 3 {
+		t.Errorf("want 3 batch calls (128+128+44), got %d", callCount)
+	}
+}
+
+// TestOpenAI_Embed_RoundTrip mirrors the Voyage round-trip test.
+func TestOpenAI_Embed_RoundTrip(t *testing.T) {
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-openai-key" {
+			t.Errorf("missing auth header")
+			http.Error(w, "no auth", 401)
+			return
+		}
+		buf := make([]byte, 4096)
+		n, _ := r.Body.Read(buf)
+		seenBody = buf[:n]
+		w.Write([]byte(`{"data":[{"embedding":[0.7,0.8],"index":0}]}`))
+	}))
+	defer srv.Close()
+
+	emb := NewOpenAIEmbedder("text-embedding-3-small", "test-openai-key", 512).WithBaseURL(srv.URL)
+	vec, err := emb.Embed("hello", InputTypeDocument)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(vec) != 2 {
+		t.Errorf("want 2-dim vector, got %d", len(vec))
+	}
+
+	var req map[string]interface{}
+	json.Unmarshal(seenBody, &req)
+	if req["model"] != "text-embedding-3-small" {
+		t.Errorf("model wrong: %v", req["model"])
+	}
+	if dim, _ := req["dimensions"].(float64); int(dim) != 512 {
+		t.Errorf("expected dimensions=512, got %v", req["dimensions"])
+	}
+	// OpenAI ignores input_type — make sure we don't send it
+	if _, hasIT := req["input_type"]; hasIT {
+		t.Errorf("openai request should not have input_type field")
+	}
+}
+
+// TestRegistry_AllCloudBackends confirms the factory can build each
+// cloud provider from config. Uses test keys (no real API calls).
+func TestRegistry_AllCloudBackends(t *testing.T) {
+	cases := []struct {
+		backend string
+		model   string
+		wantErr bool
+	}{
+		{"gemini", "gemini-embedding-001", false},
+		{"voyage", "voyage-3.5-lite", false},
+		{"openai", "text-embedding-3-small", false},
+		{"bogus", "x", true},
+	}
+	for _, tc := range cases {
+		emb, err := BuildEmbedder(BackendConfig{
+			Backend: tc.backend,
+			Model:   tc.model,
+			APIKey:  "test-key",
+			Dim:     768,
+		})
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%s: expected error", tc.backend)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", tc.backend, err)
+			continue
+		}
+		if emb.Name() != tc.backend {
+			t.Errorf("%s: got name %q", tc.backend, emb.Name())
+		}
+		if emb.Model() != tc.model {
+			t.Errorf("%s: got model %q", tc.backend, emb.Model())
+		}
+	}
+}

--- a/pkg/vectors/embedder.go
+++ b/pkg/vectors/embedder.go
@@ -1,0 +1,87 @@
+package vectors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// InputType hints the backend about how an input will be used, so it can pick
+// the right embedding optimization. Ollama and TF-IDF ignore this; Voyage and
+// Gemini use it to distinguish "this is a document to be indexed" vs
+// "this is a query looking up documents" — the two modes train differently
+// on those backends and produce better retrieval when called correctly.
+type InputType string
+
+const (
+	InputTypeDocument InputType = "document"
+	InputTypeQuery    InputType = "query"
+)
+
+// Embedder produces dense vector embeddings from text.
+//
+// Design rules (see docs/HYBRID_EMBEDDING_PLAN.md):
+//
+//  1. No silent fallback. Callers must handle Available() errors explicitly;
+//     they MUST NOT degrade to a different backend automatically.
+//  2. Available() returns an error with a recovery hint when the backend
+//     cannot be reached. The error message is shown to the user verbatim,
+//     so it must tell them exactly what to do (e.g. "run: ollama serve").
+//  3. InputType is advisory. Backends that ignore it (Ollama, TF-IDF) must
+//     accept any value without error.
+type Embedder interface {
+	// Available returns nil when the backend is healthy. On failure returns
+	// an ErrBackendUnavailable with a user-visible recovery hint.
+	Available() error
+
+	// Embed produces a single embedding. On error, callers may log + skip
+	// (write path) or fail-loud (read/search path).
+	Embed(text string, t InputType) ([]float32, error)
+
+	// EmbedBatch produces many embeddings in one round-trip. Implementations
+	// should respect MaxBatchSize (returned separately, not part of the
+	// interface to avoid forcing every backend to advertise a limit).
+	EmbedBatch(texts []string, t InputType) ([][]float32, error)
+
+	// Name is the backend identifier ("ollama", "gemini", "voyage", "openai",
+	// "tfidf"). Used in the (backend, model) composite key that tags each
+	// vector row for mixed-backend cross-machine sync.
+	Name() string
+
+	// Model is the model identifier within a backend. For Ollama this is a
+	// local tag ("nomic-embed-text", "qwen3-embedding:4b"). For cloud
+	// backends it is the vendor's model name. For TF-IDF, the literal "tfidf".
+	Model() string
+
+	// Dimensions is the length of vectors produced by this backend/model.
+	// Must be stable across calls for a given Embedder instance.
+	Dimensions() int
+}
+
+// ErrBackendUnavailable signals that the configured backend is not reachable.
+// The Hint field carries the user-facing recovery instructions.
+type ErrBackendUnavailable struct {
+	Backend string // e.g. "ollama:qwen3-embedding:4b"
+	Cause   error  // underlying connection / HTTP error
+	Hint    string // "run: ollama serve" or "export GEMINI_API_KEY=..."
+}
+
+func (e *ErrBackendUnavailable) Error() string {
+	return fmt.Sprintf("embedding backend %q unreachable: %v\n  Hint: %s",
+		e.Backend, e.Cause, e.Hint)
+}
+
+func (e *ErrBackendUnavailable) Unwrap() error {
+	return e.Cause
+}
+
+// IsBackendUnavailable reports whether err signals an unavailable backend.
+// Callers on the search/read path use this to trigger fail-loud behavior.
+var ErrNotAvailable = errors.New("backend not available")
+
+func IsBackendUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var eb *ErrBackendUnavailable
+	return errors.As(err, &eb) || errors.Is(err, ErrNotAvailable)
+}

--- a/pkg/vectors/failloud_test.go
+++ b/pkg/vectors/failloud_test.go
@@ -137,15 +137,13 @@ func TestOllamaEmbedder_Available_Reachable(t *testing.T) {
 // load-bearing UX (the plan documents it verbatim); regression here
 // silently breaks the CLI's recovery message.
 func TestOllamaEmbedder_Available_Unreachable(t *testing.T) {
-	// Create a test server then immediately close it so the URL stays
-	// valid but TCP connect returns ECONNREFUSED fast (< 1ms). Avoids
-	// the 30s dial timeout of pointing at an unreachable IP.
-	srv := newMockOllamaServer(t, 200, `{}`)
-	closedURL := srv.URL
-	srv.Close()
-
+	// Use port 1 (privileged, never bound by a real server under a normal
+	// user) → dial returns ECONNREFUSED fast and deterministically.
+	// Avoids the httptest.Close()+URL-reuse pattern whose port could
+	// theoretically be rebound by another process between Close() and
+	// the test's dial on busy CI runners.
 	emb := NewOllamaEmbedder("qwen3-embedding:4b")
-	emb.baseURL = closedURL
+	emb.baseURL = "http://127.0.0.1:1"
 
 	err := emb.Available()
 	if err == nil {
@@ -156,7 +154,9 @@ func TestOllamaEmbedder_Available_Unreachable(t *testing.T) {
 	}
 
 	var ebu *ErrBackendUnavailable
-	errors.As(err, &ebu)
+	if !errors.As(err, &ebu) {
+		t.Fatalf("could not unwrap ErrBackendUnavailable from %T: %v", err, err)
+	}
 	if ebu.Backend != "ollama:qwen3-embedding:4b" {
 		t.Errorf("Backend: want ollama:qwen3-embedding:4b, got %q", ebu.Backend)
 	}

--- a/pkg/vectors/failloud_test.go
+++ b/pkg/vectors/failloud_test.go
@@ -1,0 +1,200 @@
+package vectors
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// newMockOllamaServer returns an httptest server that responds to
+// /api/tags with the given status + body. Used to mock an Ollama
+// daemon for Available() tests without starting a real daemon.
+func newMockOllamaServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// failingEmbedder implements Embedder with all calls returning
+// ErrBackendUnavailable. Exists to simulate a down-backend scenario
+// in tests without requiring actual network.
+type failingEmbedder struct {
+	name, model string
+	hint        string
+}
+
+func newFailingEmbedder(name, model, hint string) *failingEmbedder {
+	return &failingEmbedder{name: name, model: model, hint: hint}
+}
+
+func (f *failingEmbedder) Available() error {
+	return &ErrBackendUnavailable{
+		Backend: f.name + ":" + f.model,
+		Cause:   errors.New("simulated unreachable"),
+		Hint:    f.hint,
+	}
+}
+func (f *failingEmbedder) Embed(text string, _ InputType) ([]float32, error) {
+	return nil, f.Available()
+}
+func (f *failingEmbedder) EmbedBatch(texts []string, _ InputType) ([][]float32, error) {
+	return nil, f.Available()
+}
+func (f *failingEmbedder) Name() string     { return f.name }
+func (f *failingEmbedder) Model() string    { return f.model }
+func (f *failingEmbedder) Dimensions() int  { return 768 }
+
+// TestIndexDocument_ForgivingOnEmbedFailure verifies the write-path
+// contract: if the backend is down at index time, IndexDocument logs
+// and returns nil — it MUST NOT propagate the error, because that would
+// block note creation every time the user is offline.
+//
+// This is the explicit carve-out from "no silent fallback": reads fail
+// loud, writes are forgiving. The pairing of this test + TestHybridSearch_PropagatesBackendUnavailable
+// below pins both halves of the rule in code.
+func TestIndexDocument_ForgivingOnEmbedFailure(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	emb := newFailingEmbedder("ollama", "nomic-embed-text", "run: ollama serve")
+	vs, err := NewVectorStore(db, emb)
+	if err != nil {
+		t.Fatalf("NewVectorStore: %v", err)
+	}
+
+	// IndexDocument should return nil (not the embed error), log a warning,
+	// and leave the vectors table untouched.
+	err = vs.IndexDocument("doc-1", "some content to embed")
+	if err != nil {
+		t.Errorf("IndexDocument should tolerate embed failure and return nil; got %v", err)
+	}
+
+	// Vectors table should have 0 rows — nothing was inserted because embed failed
+	n, _ := vs.CountAll()
+	if n != 0 {
+		t.Errorf("expected 0 vector rows after failed embed, got %d", n)
+	}
+}
+
+// TestSearch_PropagatesBackendUnavailable verifies the read-path contract:
+// if the backend is down during search, the error MUST propagate to the
+// caller so cmd/search.go's fail-loud + interactive recovery path can
+// trigger. Silent degradation to FTS would be a regression.
+func TestSearch_PropagatesBackendUnavailable(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	emb := newFailingEmbedder("ollama", "qwen3-embedding:4b", "run: ollama serve")
+	vs, err := NewVectorStore(db, emb)
+	if err != nil {
+		t.Fatalf("NewVectorStore: %v", err)
+	}
+
+	// No docs indexed — but the query still tries to embed, which fails.
+	_, err = vs.Search("something", 10)
+	if err == nil {
+		t.Fatal("Search should propagate backend failure; got nil error")
+	}
+	if !IsBackendUnavailable(err) {
+		t.Errorf("Search should return ErrBackendUnavailable, got %T: %v", err, err)
+	}
+
+	// Error message should include the recovery hint so the CLI can show it.
+	var ebu *ErrBackendUnavailable
+	if !errors.As(err, &ebu) {
+		t.Fatalf("expected *ErrBackendUnavailable, got %T", err)
+	}
+	if ebu.Hint != "run: ollama serve" {
+		t.Errorf("expected recovery hint 'run: ollama serve', got %q", ebu.Hint)
+	}
+	if ebu.Backend != "ollama:qwen3-embedding:4b" {
+		t.Errorf("expected Backend='ollama:qwen3-embedding:4b', got %q", ebu.Backend)
+	}
+}
+
+// TestOllamaEmbedder_Available_Reachable verifies the happy-path
+// Available() call against a mocked Ollama daemon returning 200 on /api/tags.
+func TestOllamaEmbedder_Available_Reachable(t *testing.T) {
+	srv := newMockOllamaServer(t, 200, `{"models":[{"name":"nomic-embed-text:latest"}]}`)
+	defer srv.Close()
+
+	emb := NewOllamaEmbedder("nomic-embed-text")
+	emb.baseURL = srv.URL
+	if err := emb.Available(); err != nil {
+		t.Errorf("Available should succeed on HTTP 200, got %v", err)
+	}
+}
+
+// TestOllamaEmbedder_Available_Unreachable verifies the error-path
+// contract: connection refused → ErrBackendUnavailable with a hint
+// that tells the user to run `ollama serve`. The hint text is
+// load-bearing UX (the plan documents it verbatim); regression here
+// silently breaks the CLI's recovery message.
+func TestOllamaEmbedder_Available_Unreachable(t *testing.T) {
+	// Create a test server then immediately close it so the URL stays
+	// valid but TCP connect returns ECONNREFUSED fast (< 1ms). Avoids
+	// the 30s dial timeout of pointing at an unreachable IP.
+	srv := newMockOllamaServer(t, 200, `{}`)
+	closedURL := srv.URL
+	srv.Close()
+
+	emb := NewOllamaEmbedder("qwen3-embedding:4b")
+	emb.baseURL = closedURL
+
+	err := emb.Available()
+	if err == nil {
+		t.Fatal("Available should fail when daemon is unreachable")
+	}
+	if !IsBackendUnavailable(err) {
+		t.Errorf("expected ErrBackendUnavailable, got %T: %v", err, err)
+	}
+
+	var ebu *ErrBackendUnavailable
+	errors.As(err, &ebu)
+	if ebu.Backend != "ollama:qwen3-embedding:4b" {
+		t.Errorf("Backend: want ollama:qwen3-embedding:4b, got %q", ebu.Backend)
+	}
+	// Hint must mention `ollama serve` so users know what to run
+	if !containsStr(ebu.Hint, "ollama serve") {
+		t.Errorf("Hint should mention 'ollama serve', got %q", ebu.Hint)
+	}
+}
+
+// TestOllamaEmbedder_Available_Non200 verifies graceful handling of
+// HTTP errors (daemon running but unhealthy).
+func TestOllamaEmbedder_Available_Non200(t *testing.T) {
+	srv := newMockOllamaServer(t, 503, `service temporarily unavailable`)
+	defer srv.Close()
+
+	emb := NewOllamaEmbedder("qwen3-embedding:4b")
+	emb.baseURL = srv.URL
+
+	err := emb.Available()
+	if err == nil {
+		t.Fatal("Available should fail on HTTP 503")
+	}
+	if !IsBackendUnavailable(err) {
+		t.Errorf("expected ErrBackendUnavailable, got %T", err)
+	}
+}
+
+// --- helpers ---
+
+func containsStr(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && findSub(haystack, needle) >= 0
+}
+
+func findSub(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/vectors/gemini.go
+++ b/pkg/vectors/gemini.go
@@ -1,0 +1,264 @@
+package vectors
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// GeminiEmbedder uses Google's Gemini embedding API
+// (https://generativelanguage.googleapis.com/v1beta/models/...:embedContent).
+//
+// This is the recommended cloud backend as of April 2026 — gemini-embedding-001
+// leads verified public MTEB multilingual (68.32) at $0.15/M tokens (batch
+// $0.075/M). The model supports matryoshka truncation via output_dimensionality
+// (native 3072, recommended 768 for <5K-note corpora).
+//
+// We talk to the REST API directly rather than pulling in google.golang.org/genai
+// so claudemem keeps its small dependency footprint. The two endpoints
+// (:embedContent and :batchEmbedContents) are stable and simple enough that
+// the SDK's abstraction would cost more than it saves.
+type GeminiEmbedder struct {
+	baseURL string
+	model   string
+	apiKey  string
+	dim     int
+	client  *http.Client
+}
+
+// DefaultGeminiBaseURL is the Google Generative Language API root.
+// Can be overridden via BackendConfig.Endpoint (e.g. to point at a proxy).
+const DefaultGeminiBaseURL = "https://generativelanguage.googleapis.com/v1beta"
+
+// NewGeminiEmbedder constructs an embedder. apiKey is required; callers
+// obtain it from the env var named in embedding.api_key_env (typically
+// GEMINI_API_KEY). dim is the matryoshka output size — 0 means native
+// (3072 for gemini-embedding-001), but 768 is the recommended default
+// for claudemem's corpus size.
+func NewGeminiEmbedder(model, apiKey string, dim int) *GeminiEmbedder {
+	if model == "" {
+		model = "gemini-embedding-001"
+	}
+	return &GeminiEmbedder{
+		baseURL: DefaultGeminiBaseURL,
+		model:   model,
+		apiKey:  apiKey,
+		dim:     dim,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// WithBaseURL overrides the API root (used by tests + proxy setups).
+func (g *GeminiEmbedder) WithBaseURL(u string) *GeminiEmbedder {
+	g.baseURL = u
+	return g
+}
+
+// Name identifies this backend in the (backend, model) vector tag.
+func (g *GeminiEmbedder) Name() string { return "gemini" }
+
+// Model returns the active Gemini model ID.
+func (g *GeminiEmbedder) Model() string { return g.model }
+
+// Dimensions returns the configured (possibly matryoshka-truncated) vector
+// length. Falls back to native 3072 for gemini-embedding-001 if dim==0.
+func (g *GeminiEmbedder) Dimensions() int {
+	if g.dim > 0 {
+		return g.dim
+	}
+	return 3072
+}
+
+// Available pings the Gemini API using a lightweight model metadata call.
+// Returns ErrBackendUnavailable with a recovery hint on failure — this is
+// what the fail-loud CLI layer (P4) uses to tell the user exactly what
+// to do (set GEMINI_API_KEY, check network, etc.).
+func (g *GeminiEmbedder) Available() error {
+	if g.apiKey == "" {
+		return &ErrBackendUnavailable{
+			Backend: g.Name() + ":" + g.model,
+			Cause:   fmt.Errorf("no API key configured"),
+			Hint:    "export GEMINI_API_KEY=... (or run `claudemem setup` to re-configure)",
+		}
+	}
+	// Cheapest call: fetch model metadata.
+	req, err := http.NewRequest("GET",
+		g.baseURL+"/models/"+g.model, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("x-goog-api-key", g.apiKey)
+	resp, err := g.client.Do(req)
+	if err != nil {
+		return &ErrBackendUnavailable{
+			Backend: g.Name() + ":" + g.model,
+			Cause:   err,
+			Hint:    "check network / proxy, or switch backend via `claudemem setup`",
+		}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		body, _ := io.ReadAll(resp.Body)
+		return &ErrBackendUnavailable{
+			Backend: g.Name() + ":" + g.model,
+			Cause:   fmt.Errorf("auth rejected (HTTP %d): %s", resp.StatusCode, string(body)),
+			Hint:    "verify GEMINI_API_KEY is valid; rotate at https://aistudio.google.com/app/apikey",
+		}
+	}
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return &ErrBackendUnavailable{
+			Backend: g.Name() + ":" + g.model,
+			Cause:   fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body)),
+			Hint:    "model may be unavailable in your region; try a different model or region",
+		}
+	}
+	return nil
+}
+
+// Embed calls the :embedContent endpoint for a single text.
+func (g *GeminiEmbedder) Embed(text string, t InputType) ([]float32, error) {
+	body := geminiEmbedRequest{
+		Content:             geminiContent{Parts: []geminiPart{{Text: text}}},
+		TaskType:            geminiTaskType(t),
+		OutputDimensionality: g.dim, // omitempty — 0 keeps native
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	resp, err := g.post("/models/"+g.model+":embedContent", raw)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("gemini embedContent HTTP %d: %s", resp.StatusCode, string(b))
+	}
+	var parsed geminiEmbedResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	if len(parsed.Embedding.Values) == 0 {
+		return nil, fmt.Errorf("gemini returned empty embedding")
+	}
+	return parsed.Embedding.Values, nil
+}
+
+// EmbedBatch calls :batchEmbedContents. Google caps batches at 100 requests;
+// we chunk internally so callers don't have to care.
+func (g *GeminiEmbedder) EmbedBatch(texts []string, t InputType) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	const max = 100 // Gemini batch ceiling
+	out := make([][]float32, 0, len(texts))
+
+	for i := 0; i < len(texts); i += max {
+		end := i + max
+		if end > len(texts) {
+			end = len(texts)
+		}
+		chunk := texts[i:end]
+
+		requests := make([]geminiEmbedRequest, len(chunk))
+		for j, text := range chunk {
+			requests[j] = geminiEmbedRequest{
+				Model:                "models/" + g.model, // batch API needs model on each item
+				Content:              geminiContent{Parts: []geminiPart{{Text: text}}},
+				TaskType:             geminiTaskType(t),
+				OutputDimensionality: g.dim,
+			}
+		}
+		raw, err := json.Marshal(geminiBatchRequest{Requests: requests})
+		if err != nil {
+			return nil, err
+		}
+		resp, err := g.post("/models/"+g.model+":batchEmbedContents", raw)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != 200 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, fmt.Errorf("gemini batchEmbedContents HTTP %d: %s", resp.StatusCode, string(b))
+		}
+		var parsed geminiBatchResponse
+		err = json.NewDecoder(resp.Body).Decode(&parsed)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("decode batch: %w", err)
+		}
+		if len(parsed.Embeddings) != len(chunk) {
+			return nil, fmt.Errorf("expected %d embeddings, got %d", len(chunk), len(parsed.Embeddings))
+		}
+		for _, e := range parsed.Embeddings {
+			out = append(out, e.Values)
+		}
+	}
+	return out, nil
+}
+
+// post is the shared HTTP POST helper with auth header + JSON content type.
+func (g *GeminiEmbedder) post(path string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest("POST", g.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", g.apiKey)
+	return g.client.Do(req)
+}
+
+// geminiTaskType translates our InputType enum to Gemini's task_type string.
+// These strings directly affect retrieval quality: using RETRIEVAL_QUERY for
+// query text vs RETRIEVAL_DOCUMENT for corpus docs can improve top-k accuracy
+// by ~3-5% per Google's own benchmarks.
+func geminiTaskType(t InputType) string {
+	switch t {
+	case InputTypeQuery:
+		return "RETRIEVAL_QUERY"
+	case InputTypeDocument:
+		return "RETRIEVAL_DOCUMENT"
+	default:
+		return "RETRIEVAL_DOCUMENT"
+	}
+}
+
+// --- request/response shapes ---
+
+type geminiEmbedRequest struct {
+	Model                string        `json:"model,omitempty"` // batch only
+	Content              geminiContent `json:"content"`
+	TaskType             string        `json:"taskType,omitempty"`
+	OutputDimensionality int           `json:"output_dimensionality,omitempty"`
+}
+
+type geminiContent struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiEmbedResponse struct {
+	Embedding geminiEmbeddingValues `json:"embedding"`
+}
+
+type geminiBatchRequest struct {
+	Requests []geminiEmbedRequest `json:"requests"`
+}
+
+type geminiBatchResponse struct {
+	Embeddings []geminiEmbeddingValues `json:"embeddings"`
+}
+
+type geminiEmbeddingValues struct {
+	Values []float32 `json:"values"`
+}

--- a/pkg/vectors/gemini_test.go
+++ b/pkg/vectors/gemini_test.go
@@ -1,0 +1,212 @@
+package vectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newGeminiMockServer returns an httptest server that simulates Gemini's
+// embedContent + batchEmbedContents + model metadata endpoints.
+// handler receives the request path and raw body, returns (status, body).
+func newGeminiMockServer(t *testing.T, handler func(path string, body []byte) (int, string)) (*httptest.Server, *GeminiEmbedder) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Assert auth header present on every call — enforces the contract.
+		if r.Header.Get("x-goog-api-key") == "" {
+			t.Errorf("request to %s missing x-goog-api-key header", r.URL.Path)
+			http.Error(w, "no key", http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		status, resp := handler(r.URL.Path, body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		w.Write([]byte(resp))
+	}))
+	emb := NewGeminiEmbedder("gemini-embedding-001", "test-key", 768).WithBaseURL(srv.URL)
+	return srv, emb
+}
+
+func TestGemini_Available_Success(t *testing.T) {
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		if !strings.HasSuffix(path, "/models/gemini-embedding-001") {
+			return 404, `{"error":{"message":"wrong path"}}`
+		}
+		return 200, `{"name":"models/gemini-embedding-001"}`
+	})
+	defer srv.Close()
+	if err := emb.Available(); err != nil {
+		t.Errorf("Available should return nil, got %v", err)
+	}
+}
+
+func TestGemini_Available_MissingKey(t *testing.T) {
+	emb := NewGeminiEmbedder("gemini-embedding-001", "", 768)
+	err := emb.Available()
+	if err == nil {
+		t.Fatal("expected error for missing API key")
+	}
+	if !IsBackendUnavailable(err) {
+		t.Errorf("expected ErrBackendUnavailable, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "GEMINI_API_KEY") {
+		t.Errorf("error message should mention GEMINI_API_KEY env var, got: %v", err)
+	}
+}
+
+func TestGemini_Available_AuthRejected(t *testing.T) {
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		return 401, `{"error":{"message":"invalid key"}}`
+	})
+	defer srv.Close()
+	err := emb.Available()
+	if !IsBackendUnavailable(err) {
+		t.Fatalf("expected ErrBackendUnavailable for 401, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "aistudio.google.com") {
+		t.Errorf("401 error should include key-rotation URL, got: %v", err)
+	}
+}
+
+func TestGemini_Embed_BuildsCorrectRequest(t *testing.T) {
+	var seenPath, seenBody string
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		seenPath = path
+		seenBody = string(body)
+		return 200, `{"embedding":{"values":[0.1,0.2,0.3]}}`
+	})
+	defer srv.Close()
+
+	vec, err := emb.Embed("what is the meaning of life?", InputTypeDocument)
+	if err != nil {
+		t.Fatalf("Embed failed: %v", err)
+	}
+	if len(vec) != 3 || vec[0] != 0.1 || vec[1] != 0.2 || vec[2] != 0.3 {
+		t.Errorf("unexpected vector: %v", vec)
+	}
+	// Verify request shape
+	if !strings.HasSuffix(seenPath, "/models/gemini-embedding-001:embedContent") {
+		t.Errorf("wrong path: %s", seenPath)
+	}
+	var req map[string]interface{}
+	if err := json.Unmarshal([]byte(seenBody), &req); err != nil {
+		t.Fatalf("could not parse sent body: %v", err)
+	}
+	if req["taskType"] != "RETRIEVAL_DOCUMENT" {
+		t.Errorf("expected taskType=RETRIEVAL_DOCUMENT, got %v", req["taskType"])
+	}
+	if dim, _ := req["output_dimensionality"].(float64); int(dim) != 768 {
+		t.Errorf("expected output_dimensionality=768, got %v", req["output_dimensionality"])
+	}
+	content, _ := req["content"].(map[string]interface{})
+	parts, _ := content["parts"].([]interface{})
+	firstPart, _ := parts[0].(map[string]interface{})
+	if firstPart["text"] != "what is the meaning of life?" {
+		t.Errorf("wrong text in request: %v", firstPart["text"])
+	}
+}
+
+func TestGemini_Embed_InputTypeQueryMappsCorrectly(t *testing.T) {
+	var seenBody string
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		seenBody = string(body)
+		return 200, `{"embedding":{"values":[1.0]}}`
+	})
+	defer srv.Close()
+
+	_, _ = emb.Embed("a query", InputTypeQuery)
+	if !strings.Contains(seenBody, `"taskType":"RETRIEVAL_QUERY"`) {
+		t.Errorf("InputTypeQuery did not produce RETRIEVAL_QUERY taskType, body: %s", seenBody)
+	}
+}
+
+func TestGemini_EmbedBatch_ChunksOverOneHundred(t *testing.T) {
+	// 250 inputs → should produce 3 batch calls (100, 100, 50)
+	batchCallCount := 0
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		if !strings.HasSuffix(path, ":batchEmbedContents") {
+			return 404, `{}`
+		}
+		batchCallCount++
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		requests, _ := req["requests"].([]interface{})
+		// Echo back one 4-dim vector per input
+		embeddings := make([]string, len(requests))
+		for i := range requests {
+			embeddings[i] = fmt.Sprintf(`{"values":[%d.0, 1.0, 2.0, 3.0]}`, i)
+		}
+		return 200, `{"embeddings":[` + strings.Join(embeddings, ",") + `]}`
+	})
+	defer srv.Close()
+
+	texts := make([]string, 250)
+	for i := range texts {
+		texts[i] = fmt.Sprintf("doc %d", i)
+	}
+	vectors, err := emb.EmbedBatch(texts, InputTypeDocument)
+	if err != nil {
+		t.Fatalf("EmbedBatch failed: %v", err)
+	}
+	if len(vectors) != 250 {
+		t.Errorf("expected 250 vectors, got %d", len(vectors))
+	}
+	if batchCallCount != 3 {
+		t.Errorf("expected 3 batch calls for 250 inputs (100/100/50), got %d", batchCallCount)
+	}
+}
+
+func TestGemini_Embed_ErrorBody(t *testing.T) {
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		return 400, `{"error":{"message":"content too long"}}`
+	})
+	defer srv.Close()
+	_, err := emb.Embed("hello", InputTypeDocument)
+	if err == nil {
+		t.Fatal("expected error on HTTP 400")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error should include status code, got: %v", err)
+	}
+}
+
+func TestGemini_Name_Model_Dimensions(t *testing.T) {
+	emb := NewGeminiEmbedder("gemini-embedding-001", "k", 1024)
+	if emb.Name() != "gemini" {
+		t.Errorf("Name: want gemini, got %s", emb.Name())
+	}
+	if emb.Model() != "gemini-embedding-001" {
+		t.Errorf("Model: want gemini-embedding-001, got %s", emb.Model())
+	}
+	if emb.Dimensions() != 1024 {
+		t.Errorf("Dimensions: want 1024, got %d", emb.Dimensions())
+	}
+	// Native fallback when dim=0
+	emb2 := NewGeminiEmbedder("gemini-embedding-001", "k", 0)
+	if emb2.Dimensions() != 3072 {
+		t.Errorf("native Dimensions: want 3072, got %d", emb2.Dimensions())
+	}
+}
+
+func TestGemini_Registry_BuildsFromConfig(t *testing.T) {
+	cfg := BackendConfig{
+		Backend: "gemini",
+		Model:   "gemini-embedding-001",
+		APIKey:  "test-key",
+		Dim:     768,
+	}
+	emb, err := BuildEmbedder(cfg)
+	if err != nil {
+		t.Fatalf("BuildEmbedder: %v", err)
+	}
+	if emb.Name() != "gemini" {
+		t.Errorf("expected gemini backend, got %s", emb.Name())
+	}
+	if emb.Dimensions() != 768 {
+		t.Errorf("expected 768 dims, got %d", emb.Dimensions())
+	}
+}

--- a/pkg/vectors/health.go
+++ b/pkg/vectors/health.go
@@ -154,7 +154,7 @@ func CheckHealthDeep(in HealthInputs) (*HealthReport, error) {
 
 	// I5 — vector_meta.index_backend matches active embedder
 	if in.Embedder != nil {
-		meta := readMeta(in.DB, "index_backend")
+		meta := readMetaOrEmpty(in.DB, "index_backend")
 		expected := in.Embedder.Name() + ":" + in.Embedder.Model()
 		r.I5VectorMetaMatchesActive = meta == expected || meta == ""
 		if !r.I5VectorMetaMatchesActive {

--- a/pkg/vectors/health.go
+++ b/pkg/vectors/health.go
@@ -1,0 +1,198 @@
+package vectors
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HealthReport is the result of a parity check. Each invariant (I1–I5) has
+// a boolean pass/fail + a human-readable message. Quick health check
+// populates I1–I3; Deep also fills I4 + I5 (orphans + config match).
+type HealthReport struct {
+	// Counts
+	MarkdownFiles int            // I1 lhs
+	EntriesTotal  int            // I1 rhs
+	FTSTotal      int            // I2 rhs
+	VectorTotals  map[string]int // key = "backend:model", value = rows
+
+	// Active backend at check time
+	ActiveBackend string
+	ActiveModel   string
+
+	// Per-invariant status. False = drift detected.
+	I1MarkdownMatchesEntries bool
+	I2EntriesMatchesFTS      bool
+	I3VectorsMatchActiveBackend bool
+	I4NoOrphanRows               bool // deep only
+	I5VectorMetaMatchesActive    bool // deep only
+
+	// Human-readable drift descriptions (empty when all pass)
+	Issues []string
+
+	// DidDeepCheck reports whether I4+I5 were evaluated.
+	DidDeepCheck bool
+}
+
+// Healthy reports whether all populated invariants pass.
+func (h *HealthReport) Healthy() bool {
+	base := h.I1MarkdownMatchesEntries &&
+		h.I2EntriesMatchesFTS &&
+		h.I3VectorsMatchActiveBackend
+	if !h.DidDeepCheck {
+		return base
+	}
+	return base && h.I4NoOrphanRows && h.I5VectorMetaMatchesActive
+}
+
+// HealthInputs are the paths + DB handle + active Embedder needed to run
+// a parity check. Separated so tests can pass temp dirs + fake embedders.
+type HealthInputs struct {
+	DB          *sql.DB
+	NotesDir    string
+	SessionsDir string
+	Embedder    Embedder // may be nil — I3 is then skipped
+}
+
+// CheckHealth runs the quick parity check (I1–I3). Targets sub-100ms so
+// it can run on every SessionStart hook without blocking the shell.
+func CheckHealth(in HealthInputs) (*HealthReport, error) {
+	r := &HealthReport{VectorTotals: map[string]int{}}
+
+	// I1 — markdown files vs entries table
+	mdCount, err := countMarkdownFiles(in.NotesDir, in.SessionsDir)
+	if err != nil {
+		return nil, fmt.Errorf("scan markdown: %w", err)
+	}
+	r.MarkdownFiles = mdCount
+	if err := in.DB.QueryRow(`SELECT COUNT(*) FROM entries`).Scan(&r.EntriesTotal); err != nil {
+		return nil, fmt.Errorf("count entries: %w", err)
+	}
+	r.I1MarkdownMatchesEntries = mdCount == r.EntriesTotal
+	if !r.I1MarkdownMatchesEntries {
+		r.Issues = append(r.Issues, fmt.Sprintf(
+			"I1: %d markdown files but %d entries rows (delta %d). Run `claudemem reindex`.",
+			mdCount, r.EntriesTotal, mdCount-r.EntriesTotal))
+	}
+
+	// I2 — entries vs memory_fts
+	if err := in.DB.QueryRow(`SELECT COUNT(*) FROM memory_fts`).Scan(&r.FTSTotal); err != nil {
+		return nil, fmt.Errorf("count fts: %w", err)
+	}
+	r.I2EntriesMatchesFTS = r.EntriesTotal == r.FTSTotal
+	if !r.I2EntriesMatchesFTS {
+		r.Issues = append(r.Issues, fmt.Sprintf(
+			"I2: %d entries but %d memory_fts rows. Run `claudemem reindex`.",
+			r.EntriesTotal, r.FTSTotal))
+	}
+
+	// I3 — per-(backend, model) vector counts (compared to entries)
+	rows, err := in.DB.Query(`SELECT backend, model, COUNT(*) FROM vectors GROUP BY backend, model`)
+	if err != nil {
+		return nil, fmt.Errorf("group vectors: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var backend, model string
+		var n int
+		if err := rows.Scan(&backend, &model, &n); err != nil {
+			return nil, err
+		}
+		r.VectorTotals[backend+":"+model] = n
+	}
+	if in.Embedder != nil {
+		r.ActiveBackend = in.Embedder.Name()
+		r.ActiveModel = in.Embedder.Model()
+		key := r.ActiveBackend + ":" + r.ActiveModel
+		active := r.VectorTotals[key]
+		r.I3VectorsMatchActiveBackend = active == r.EntriesTotal
+		if !r.I3VectorsMatchActiveBackend {
+			r.Issues = append(r.Issues, fmt.Sprintf(
+				"I3: active backend %s has %d vectors but %d entries expect them (delta %d). Run `claudemem repair` to backfill.",
+				key, active, r.EntriesTotal, r.EntriesTotal-active))
+		}
+	} else {
+		// No embedder passed — skip I3 rather than claim false pass
+		r.I3VectorsMatchActiveBackend = true
+	}
+
+	return r, nil
+}
+
+// CheckHealthDeep also runs I4 (no orphans) + I5 (vector_meta matches).
+// Slower: scans every FTS and every vector row against entries.
+func CheckHealthDeep(in HealthInputs) (*HealthReport, error) {
+	r, err := CheckHealth(in)
+	if err != nil {
+		return nil, err
+	}
+	r.DidDeepCheck = true
+
+	// I4 — orphan FTS rows pointing to non-existent entries
+	var orphanFTS int
+	if err := in.DB.QueryRow(`
+		SELECT COUNT(*) FROM memory_fts
+		WHERE id NOT IN (SELECT id FROM entries)
+	`).Scan(&orphanFTS); err != nil {
+		return nil, err
+	}
+	var orphanVec int
+	if err := in.DB.QueryRow(`
+		SELECT COUNT(*) FROM vectors
+		WHERE doc_id NOT IN (SELECT id FROM entries)
+	`).Scan(&orphanVec); err != nil {
+		return nil, err
+	}
+	r.I4NoOrphanRows = orphanFTS == 0 && orphanVec == 0
+	if !r.I4NoOrphanRows {
+		r.Issues = append(r.Issues, fmt.Sprintf(
+			"I4: %d orphan FTS rows, %d orphan vector rows (parent entry deleted). Run `claudemem repair`.",
+			orphanFTS, orphanVec))
+	}
+
+	// I5 — vector_meta.index_backend matches active embedder
+	if in.Embedder != nil {
+		meta := readMeta(in.DB, "index_backend")
+		expected := in.Embedder.Name() + ":" + in.Embedder.Model()
+		r.I5VectorMetaMatchesActive = meta == expected || meta == ""
+		if !r.I5VectorMetaMatchesActive {
+			r.Issues = append(r.Issues, fmt.Sprintf(
+				"I5: vector_meta.index_backend=%q but active=%q. Reindex after backend switch: `claudemem reindex --vectors`.",
+				meta, expected))
+		}
+	} else {
+		r.I5VectorMetaMatchesActive = true
+	}
+
+	return r, nil
+}
+
+// countMarkdownFiles walks notesDir + sessionsDir and counts .md files.
+// Called once per SessionStart — keep it cheap. Exits early if either
+// directory does not exist (fresh install).
+func countMarkdownFiles(notesDir, sessionsDir string) (int, error) {
+	total := 0
+	for _, dir := range []string{notesDir, sessionsDir} {
+		if _, err := os.Stat(dir); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return 0, err
+		}
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return nil
+			}
+			if strings.HasSuffix(info.Name(), ".md") {
+				total++
+			}
+			return nil
+		})
+		if err != nil {
+			return 0, err
+		}
+	}
+	return total, nil
+}

--- a/pkg/vectors/health_test.go
+++ b/pkg/vectors/health_test.go
@@ -1,0 +1,169 @@
+package vectors
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupHealthTestDB creates a temp DB with entries + memory_fts + v22 vectors
+// tables, plus temp notes/sessions directories. Returns paths and cleanup.
+func setupHealthTestDB(t *testing.T) (*sql.DB, string, string) {
+	t.Helper()
+	db := setupTestDB(t)
+
+	schema := `
+	CREATE TABLE entries (
+		id TEXT PRIMARY KEY,
+		type TEXT NOT NULL,
+		title TEXT NOT NULL,
+		filepath TEXT NOT NULL
+	);
+	CREATE VIRTUAL TABLE memory_fts USING fts5(id UNINDEXED, title, content, tags);
+	`
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+
+	// Also make sure the v22 vectors schema exists (initSchema creates it)
+	if _, err := NewVectorStore(db, NewTFIDFEmbedder()); err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+
+	base := t.TempDir()
+	notes := filepath.Join(base, "notes")
+	sessions := filepath.Join(base, "sessions")
+	os.MkdirAll(notes, 0755)
+	os.MkdirAll(sessions, 0755)
+	return db, notes, sessions
+}
+
+func seedNote(t *testing.T, db *sql.DB, notesDir, id, title string) {
+	t.Helper()
+	path := filepath.Join(notesDir, id+".md")
+	if err := os.WriteFile(path, []byte("content for "+id), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO entries (id, type, title, filepath) VALUES (?, 'note', ?, ?)`,
+		id, title, "notes/"+id+".md"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO memory_fts (id, title, content, tags) VALUES (?, ?, ?, '')`,
+		id, title, "content"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestHealthCheck_HealthyState verifies that when filesystem, entries, FTS,
+// and vectors all agree, the check returns Healthy()=true with no issues.
+func TestHealthCheck_HealthyState(t *testing.T) {
+	db, notes, sessions := setupHealthTestDB(t)
+	defer db.Close()
+
+	seedNote(t, db, notes, "doc1", "First Note")
+	seedNote(t, db, notes, "doc2", "Second Note")
+
+	// Build TF-IDF vectors matching entries
+	vs, _ := NewVectorStore(db, NewTFIDFEmbedder())
+	_ = vs.RebuildIndex([]Document{
+		{ID: "doc1", Text: "first note content"},
+		{ID: "doc2", Text: "second note content"},
+	})
+
+	r, err := CheckHealth(HealthInputs{
+		DB: db, NotesDir: notes, SessionsDir: sessions,
+		Embedder: NewTFIDFEmbedder(),
+	})
+	if err != nil {
+		t.Fatalf("CheckHealth: %v", err)
+	}
+
+	if !r.Healthy() {
+		t.Errorf("expected healthy state, got issues: %v", r.Issues)
+	}
+	if r.MarkdownFiles != 2 || r.EntriesTotal != 2 || r.FTSTotal != 2 {
+		t.Errorf("count mismatch: md=%d entries=%d fts=%d", r.MarkdownFiles, r.EntriesTotal, r.FTSTotal)
+	}
+}
+
+// TestHealthCheck_DetectsFTSDrift inserts an entry without its FTS row
+// and verifies I2 fires.
+func TestHealthCheck_DetectsFTSDrift(t *testing.T) {
+	db, notes, sessions := setupHealthTestDB(t)
+	defer db.Close()
+
+	seedNote(t, db, notes, "doc1", "First")
+	// Intentionally skip FTS insert
+	path := filepath.Join(notes, "orphan.md")
+	os.WriteFile(path, []byte("x"), 0644)
+	db.Exec(`INSERT INTO entries (id, type, title, filepath) VALUES ('orphan', 'note', 'Orphan', 'notes/orphan.md')`)
+	// No FTS row for 'orphan'
+
+	r, _ := CheckHealth(HealthInputs{
+		DB: db, NotesDir: notes, SessionsDir: sessions,
+	})
+	if r.I2EntriesMatchesFTS {
+		t.Error("expected I2 drift (missing FTS row), got pass")
+	}
+	found := false
+	for _, issue := range r.Issues {
+		if contains1(issue, "I2:") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an I2 issue in report, got: %v", r.Issues)
+	}
+}
+
+// TestHealthCheck_DetectsMissingVectorsForBackend verifies I3 fires when
+// entries exist but the active backend has no embeddings for them
+// (post-backend-switch pre-reindex state).
+func TestHealthCheck_DetectsMissingVectorsForBackend(t *testing.T) {
+	db, notes, sessions := setupHealthTestDB(t)
+	defer db.Close()
+
+	seedNote(t, db, notes, "doc1", "First")
+	seedNote(t, db, notes, "doc2", "Second")
+	// Entries + FTS present. Vectors table intentionally empty.
+
+	r, _ := CheckHealth(HealthInputs{
+		DB: db, NotesDir: notes, SessionsDir: sessions,
+		Embedder: NewTFIDFEmbedder(),
+	})
+	if r.I3VectorsMatchActiveBackend {
+		t.Error("expected I3 drift (no vectors for active backend), got pass")
+	}
+}
+
+// TestHealthCheckDeep_DetectsOrphanRows exercises I4.
+func TestHealthCheckDeep_DetectsOrphanRows(t *testing.T) {
+	db, notes, sessions := setupHealthTestDB(t)
+	defer db.Close()
+
+	seedNote(t, db, notes, "doc1", "Valid")
+	// Insert an orphan FTS row pointing at a non-existent entry
+	db.Exec(`INSERT INTO memory_fts (id, title, content, tags) VALUES ('ghost', 'Ghost', 'x', '')`)
+
+	r, err := CheckHealthDeep(HealthInputs{
+		DB: db, NotesDir: notes, SessionsDir: sessions,
+		Embedder: NewTFIDFEmbedder(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.I4NoOrphanRows {
+		t.Error("expected I4 drift (ghost FTS row), got pass")
+	}
+}
+
+// helper (avoid importing strings just for this)
+func contains1(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/vectors/migration_test.go
+++ b/pkg/vectors/migration_test.go
@@ -1,0 +1,251 @@
+package vectors
+
+import (
+	"database/sql"
+	"encoding/binary"
+	"math"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestMigrateV21ToV22_PreservesVectors simulates the MacBook upgrade path:
+// a pre-refactor DB already has a flat (id, vector) vectors table populated
+// with Ollama/nomic-embed-text 768-dim rows. The migration must:
+//
+//  1. Detect the v21 schema via PRAGMA table_info
+//  2. Read vector_meta.index_backend to learn the originating backend
+//  3. Copy every row into the new schema, tagged with (ollama, nomic-embed-text, 768)
+//  4. Preserve the exact vector bytes so CosineSimilarity results don't change
+//  5. Drop the old table
+//
+// If this test fails, real users' Ollama-embedded knowledge gets lost on upgrade.
+func TestMigrateV21ToV22_PreservesVectors(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// --- Set up a realistic v21 database ---
+	if _, err := db.Exec(`
+		CREATE TABLE vector_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		CREATE TABLE vectors (id TEXT PRIMARY KEY, vector BLOB NOT NULL);
+	`); err != nil {
+		t.Fatalf("setup v21: %v", err)
+	}
+	if _, err := db.Exec(`INSERT INTO vector_meta (key, value) VALUES ('index_backend', 'ollama:nomic-embed-text')`); err != nil {
+		t.Fatalf("seed meta: %v", err)
+	}
+	// Two 768-dim vectors — simulate real Ollama-embedded content
+	docA := make768DimVector(0.42)
+	docB := make768DimVector(-0.17)
+	blobA := make([]byte, 768*4)
+	blobB := make([]byte, 768*4)
+	for i, v := range docA {
+		binary.LittleEndian.PutUint32(blobA[i*4:], math.Float32bits(v))
+	}
+	for i, v := range docB {
+		binary.LittleEndian.PutUint32(blobB[i*4:], math.Float32bits(v))
+	}
+	if _, err := db.Exec(`INSERT INTO vectors (id, vector) VALUES (?, ?), (?, ?)`,
+		"docA", blobA, "docB", blobB); err != nil {
+		t.Fatalf("seed rows: %v", err)
+	}
+
+	// --- Run the migration via NewVectorStore (it calls initSchema which detects + migrates) ---
+	vs, err := NewVectorStore(db, NewTFIDFEmbedder())
+	if err != nil {
+		t.Fatalf("NewVectorStore (migration): %v", err)
+	}
+
+	// --- Verify: the vectors table should now have 2 v22-shaped rows ---
+	kind, err := detectVectorsSchema(db)
+	if err != nil {
+		t.Fatalf("detect schema: %v", err)
+	}
+	if kind != schemaV22 {
+		t.Fatalf("expected v22 schema after migration, got %d", kind)
+	}
+
+	var count int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM vectors`).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 preserved rows, got %d", count)
+	}
+
+	// Tags must match the legacy backend tuple
+	rows, err := db.Query(`SELECT doc_id, backend, model, dim FROM vectors ORDER BY doc_id`)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	defer rows.Close()
+	var seen []string
+	for rows.Next() {
+		var docID, backend, model string
+		var dim int
+		if err := rows.Scan(&docID, &backend, &model, &dim); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if backend != "ollama" {
+			t.Errorf("doc %s: expected backend=ollama, got %s", docID, backend)
+		}
+		if model != "nomic-embed-text" {
+			t.Errorf("doc %s: expected model=nomic-embed-text, got %s", docID, model)
+		}
+		if dim != 768 {
+			t.Errorf("doc %s: expected dim=768, got %d", docID, dim)
+		}
+		seen = append(seen, docID)
+	}
+	if len(seen) != 2 || seen[0] != "docA" || seen[1] != "docB" {
+		t.Errorf("expected [docA docB], got %v", seen)
+	}
+
+	// vectors_v21 table must be dropped
+	var tbl string
+	err = db.QueryRow(`SELECT name FROM sqlite_master WHERE type='table' AND name='vectors_v21'`).Scan(&tbl)
+	if err != sql.ErrNoRows {
+		t.Errorf("vectors_v21 table should be dropped after migration (got %q, err=%v)", tbl, err)
+	}
+
+	// Re-running NewVectorStore must be idempotent (no re-migration)
+	_, err = NewVectorStore(db, NewTFIDFEmbedder())
+	if err != nil {
+		t.Fatalf("second NewVectorStore call: %v", err)
+	}
+	_ = vs
+}
+
+// TestMigrateV21ToV22_LegacyTFIDFBackend covers the case where vector_meta
+// has the bare string "tfidf" (very old installs before 66c3fdc added the
+// backend:model tuple format).
+func TestMigrateV21ToV22_LegacyTFIDFBackend(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	if _, err := db.Exec(`
+		CREATE TABLE vector_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		CREATE TABLE vectors (id TEXT PRIMARY KEY, vector BLOB NOT NULL);
+		INSERT INTO vector_meta (key, value) VALUES ('index_backend', 'tfidf');
+	`); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// 100-dim TF-IDF vector
+	vec := make([]float32, 100)
+	vec[5] = 1.0
+	blob := make([]byte, 100*4)
+	for i, v := range vec {
+		binary.LittleEndian.PutUint32(blob[i*4:], math.Float32bits(v))
+	}
+	if _, err := db.Exec(`INSERT INTO vectors (id, vector) VALUES (?, ?)`, "xyz", blob); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	_, err := NewVectorStore(db, NewTFIDFEmbedder())
+	if err != nil {
+		t.Fatalf("migration: %v", err)
+	}
+
+	var backend, model string
+	var dim int
+	if err := db.QueryRow(`SELECT backend, model, dim FROM vectors WHERE doc_id='xyz'`).
+		Scan(&backend, &model, &dim); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if backend != "tfidf" || model != "tfidf" || dim != 100 {
+		t.Errorf("expected (tfidf, tfidf, 100), got (%s, %s, %d)", backend, model, dim)
+	}
+}
+
+// TestPerDocMetadata_MixedBackendsCoexist validates the cross-machine sync
+// invariant: two different (backend, model) tuples can have vectors for
+// the same doc_id, and queries filter by active backend — so the two
+// don't pollute each other.
+func TestPerDocMetadata_MixedBackendsCoexist(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	// Machine A — TF-IDF
+	vsTFIDF, err := NewVectorStore(db, NewTFIDFEmbedder())
+	if err != nil {
+		t.Fatalf("init tfidf: %v", err)
+	}
+	if err := vsTFIDF.RebuildIndex([]Document{
+		{ID: "doc1", Text: "authentication tokens OAuth JWT secure"},
+		{ID: "doc2", Text: "database migration schema indexing"},
+	}); err != nil {
+		t.Fatalf("rebuild tfidf: %v", err)
+	}
+
+	// Simulate Machine B joining — a different embedder with its own rows
+	// for the SAME doc_ids. Use a synthetic "fake-cloud" embedder so we can
+	// control the backend name/model/dim for the assertion.
+	fake := &fakeEmbedder{name: "fake-cloud", model: "fake-v1", dim: 4}
+	vsFake, err := NewVectorStore(db, fake)
+	if err != nil {
+		t.Fatalf("init fake: %v", err)
+	}
+	if err := vsFake.RebuildIndex([]Document{
+		{ID: "doc1", Text: "some cloud-embedded content"},
+		{ID: "doc2", Text: "other cloud-embedded content"},
+	}); err != nil {
+		t.Fatalf("rebuild fake: %v", err)
+	}
+
+	// Total rows should be 4: 2 docs × 2 backends
+	total, err := vsFake.CountAll()
+	if err != nil || total != 4 {
+		t.Errorf("expected 4 total rows after dual-backend reindex, got %d (err=%v)", total, err)
+	}
+
+	// Each VectorStore's Count() sees only its own backend
+	a, _ := vsTFIDF.Count()
+	b, _ := vsFake.Count()
+	if a != 2 || b != 2 {
+		t.Errorf("expected (tfidf=2, fake=2), got (tfidf=%d, fake=%d)", a, b)
+	}
+}
+
+// --- Test helpers ---
+
+func make768DimVector(seed float32) []float32 {
+	v := make([]float32, 768)
+	for i := range v {
+		// deterministic but non-trivial — depends on seed and position
+		v[i] = seed * float32(math.Sin(float64(i)*0.01))
+	}
+	return v
+}
+
+// fakeEmbedder returns a fixed-dim vector whose content is a hash of the
+// input string, so it's deterministic across runs and different-per-text.
+type fakeEmbedder struct {
+	name, model string
+	dim         int
+}
+
+func (f *fakeEmbedder) Available() error        { return nil }
+func (f *fakeEmbedder) Name() string            { return f.name }
+func (f *fakeEmbedder) Model() string           { return f.model }
+func (f *fakeEmbedder) Dimensions() int         { return f.dim }
+func (f *fakeEmbedder) Embed(text string, _ InputType) ([]float32, error) {
+	vec := make([]float32, f.dim)
+	for i := 0; i < f.dim; i++ {
+		// Fill with a function of the text + position so different texts
+		// get different vectors. Cheap hash, not cryptographic.
+		h := 0
+		for _, r := range text {
+			h = h*31 + int(r) + i
+		}
+		vec[i] = float32(h%1000) / 1000.0
+	}
+	return vec, nil
+}
+func (f *fakeEmbedder) EmbedBatch(texts []string, t InputType) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, txt := range texts {
+		v, _ := f.Embed(txt, t)
+		out[i] = v
+	}
+	return out, nil
+}

--- a/pkg/vectors/ollama.go
+++ b/pkg/vectors/ollama.go
@@ -48,19 +48,43 @@ func NewOllamaEmbedder(model string) *OllamaEmbedder {
 	}
 }
 
-// Available checks if Ollama is running and the embedding model is available.
-func (o *OllamaEmbedder) Available() bool {
-	// Quick health check
+// Available returns nil if the Ollama daemon is reachable. On failure it
+// returns an ErrBackendUnavailable carrying a recovery hint — this is the
+// failure signal the search/read path uses to fail loud instead of falling
+// back to TF-IDF silently.
+func (o *OllamaEmbedder) Available() error {
 	resp, err := o.client.Get(o.baseURL + "/api/tags")
 	if err != nil {
-		return false
+		return &ErrBackendUnavailable{
+			Backend: o.Name() + ":" + o.model,
+			Cause:   err,
+			Hint:    "start the daemon: `ollama serve` (or switch backend: `claudemem setup`)",
+		}
 	}
 	defer resp.Body.Close()
-	return resp.StatusCode == 200
+	if resp.StatusCode != 200 {
+		return &ErrBackendUnavailable{
+			Backend: o.Name() + ":" + o.model,
+			Cause:   fmt.Errorf("ollama /api/tags returned HTTP %d", resp.StatusCode),
+			Hint:    "check `ollama serve` logs or run `claudemem setup` to switch backend",
+		}
+	}
+	return nil
 }
 
-// Embed generates an embedding vector for a single text input.
-func (o *OllamaEmbedder) Embed(text string) ([]float32, error) {
+// Name returns "ollama" — the backend identifier used in the composite
+// (backend, model) key that tags each vector row.
+func (o *OllamaEmbedder) Name() string { return "ollama" }
+
+// Dimensions returns the vector length produced by this model. Returns 0
+// until the first successful Embed call (Ollama does not advertise dims
+// up-front, so we cache after observing the first response).
+func (o *OllamaEmbedder) Dimensions() int { return o.dims }
+
+// Embed generates an embedding. The InputType hint is accepted for interface
+// conformance and ignored — Ollama does not distinguish document vs query
+// modes at the API level.
+func (o *OllamaEmbedder) Embed(text string, _ InputType) ([]float32, error) {
 	reqBody := embedRequest{
 		Model: o.model,
 		Input: text,
@@ -105,7 +129,8 @@ func (o *OllamaEmbedder) Embed(text string) ([]float32, error) {
 }
 
 // EmbedBatch generates embeddings for multiple texts in one request.
-func (o *OllamaEmbedder) EmbedBatch(texts []string) ([][]float32, error) {
+// InputType is accepted for interface conformance and ignored (see Embed).
+func (o *OllamaEmbedder) EmbedBatch(texts []string, _ InputType) ([][]float32, error) {
 	if len(texts) == 0 {
 		return nil, nil
 	}
@@ -151,11 +176,6 @@ func (o *OllamaEmbedder) EmbedBatch(texts []string) ([][]float32, error) {
 	}
 
 	return result.Embeddings, nil
-}
-
-// Dims returns the embedding dimension size (0 if no embedding generated yet).
-func (o *OllamaEmbedder) Dims() int {
-	return o.dims
 }
 
 // Model returns the model name being used.

--- a/pkg/vectors/openai.go
+++ b/pkg/vectors/openai.go
@@ -1,0 +1,184 @@
+package vectors
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// OpenAIEmbedder uses OpenAI's v1/embeddings endpoint.
+//
+// text-embedding-3-small is the budget English-focused option
+// ($0.02/M tokens, 1536 native → 512 truncatable via dimensions).
+// Weaker Chinese retrieval than Gemini/Voyage — use only if your
+// corpus is English-dominant and you're already paying for OpenAI
+// for other reasons.
+//
+// No input_type distinction — OpenAI doesn't differentiate
+// document/query at the API level. The parameter is accepted
+// for interface compliance and ignored.
+//
+// See: https://platform.openai.com/docs/guides/embeddings
+type OpenAIEmbedder struct {
+	baseURL string
+	model   string
+	apiKey  string
+	dim     int
+	client  *http.Client
+}
+
+const DefaultOpenAIBaseURL = "https://api.openai.com/v1"
+
+func NewOpenAIEmbedder(model, apiKey string, dim int) *OpenAIEmbedder {
+	if model == "" {
+		model = "text-embedding-3-small"
+	}
+	return &OpenAIEmbedder{
+		baseURL: DefaultOpenAIBaseURL,
+		model:   model,
+		apiKey:  apiKey,
+		dim:     dim,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (o *OpenAIEmbedder) WithBaseURL(u string) *OpenAIEmbedder {
+	o.baseURL = u
+	return o
+}
+
+func (o *OpenAIEmbedder) Name() string  { return "openai" }
+func (o *OpenAIEmbedder) Model() string { return o.model }
+func (o *OpenAIEmbedder) Dimensions() int {
+	if o.dim > 0 {
+		return o.dim
+	}
+	// Native sizes: 3-small 1536, 3-large 3072. Callers should set dim
+	// explicitly for anything other than 3-small.
+	return 1536
+}
+
+func (o *OpenAIEmbedder) Available() error {
+	if o.apiKey == "" {
+		return &ErrBackendUnavailable{
+			Backend: "openai:" + o.model,
+			Cause:   fmt.Errorf("no API key configured"),
+			Hint:    "export OPENAI_API_KEY=... (or run `claudemem setup`)",
+		}
+	}
+	// List-models is cheap and auth-scoped.
+	req, _ := http.NewRequest("GET", o.baseURL+"/models/"+o.model, nil)
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return &ErrBackendUnavailable{
+			Backend: "openai:" + o.model,
+			Cause:   err,
+			Hint:    "check network / proxy, or switch backend via `claudemem setup`",
+		}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return &ErrBackendUnavailable{
+			Backend: "openai:" + o.model,
+			Cause:   fmt.Errorf("auth rejected (HTTP %d)", resp.StatusCode),
+			Hint:    "rotate key at https://platform.openai.com/api-keys",
+		}
+	}
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return &ErrBackendUnavailable{
+			Backend: "openai:" + o.model,
+			Cause:   fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(b)),
+			Hint:    "check model name and API status at https://status.openai.com",
+		}
+	}
+	return nil
+}
+
+func (o *OpenAIEmbedder) Embed(text string, t InputType) ([]float32, error) {
+	vecs, err := o.EmbedBatch([]string{text}, t)
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("openai returned no embeddings")
+	}
+	return vecs[0], nil
+}
+
+func (o *OpenAIEmbedder) EmbedBatch(texts []string, _ InputType) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	const max = 2048 // OpenAI batch limit
+	out := make([][]float32, 0, len(texts))
+	for i := 0; i < len(texts); i += max {
+		end := i + max
+		if end > len(texts) {
+			end = len(texts)
+		}
+		chunk := texts[i:end]
+		vecs, err := o.embedBatchOne(chunk)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (o *OpenAIEmbedder) embedBatchOne(texts []string) ([][]float32, error) {
+	body := openaiRequest{
+		Input:      texts,
+		Model:      o.model,
+		Dimensions: o.dim,
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", o.baseURL+"/embeddings", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("openai request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("openai HTTP %d: %s", resp.StatusCode, string(b))
+	}
+	var parsed openaiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode openai: %w", err)
+	}
+	out := make([][]float32, len(parsed.Data))
+	for _, d := range parsed.Data {
+		if d.Index < 0 || d.Index >= len(out) {
+			return nil, fmt.Errorf("openai returned out-of-range index %d", d.Index)
+		}
+		out[d.Index] = d.Embedding
+	}
+	return out, nil
+}
+
+type openaiRequest struct {
+	Input      []string `json:"input"`
+	Model      string   `json:"model"`
+	Dimensions int      `json:"dimensions,omitempty"`
+}
+
+type openaiResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+}

--- a/pkg/vectors/openai.go
+++ b/pkg/vectors/openai.go
@@ -70,7 +70,14 @@ func (o *OpenAIEmbedder) Available() error {
 		}
 	}
 	// List-models is cheap and auth-scoped.
-	req, _ := http.NewRequest("GET", o.baseURL+"/models/"+o.model, nil)
+	req, err := http.NewRequest("GET", o.baseURL+"/models/"+o.model, nil)
+	if err != nil {
+		return &ErrBackendUnavailable{
+			Backend: "openai:" + o.model,
+			Cause:   fmt.Errorf("build request: %w", err),
+			Hint:    "check embedding.endpoint config — is the URL well-formed?",
+		}
+	}
 	req.Header.Set("Authorization", "Bearer "+o.apiKey)
 	resp, err := o.client.Do(req)
 	if err != nil {
@@ -160,7 +167,14 @@ func (o *OpenAIEmbedder) embedBatchOne(texts []string) ([][]float32, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, fmt.Errorf("decode openai: %w", err)
 	}
-	out := make([][]float32, len(parsed.Data))
+	// Defensive: size by INPUT length and verify response count matches.
+	// Partial responses would otherwise panic in RebuildIndex at
+	// `embeddings[j]`. Matches Gemini's guard.
+	if len(parsed.Data) != len(texts) {
+		return nil, fmt.Errorf("openai returned %d embeddings for %d inputs (partial response not supported)",
+			len(parsed.Data), len(texts))
+	}
+	out := make([][]float32, len(texts))
 	for _, d := range parsed.Data {
 		if d.Index < 0 || d.Index >= len(out) {
 			return nil, fmt.Errorf("openai returned out-of-range index %d", d.Index)

--- a/pkg/vectors/registry.go
+++ b/pkg/vectors/registry.go
@@ -36,7 +36,15 @@ func BuildEmbedder(cfg BackendConfig) (Embedder, error) {
 		return emb, nil
 
 	case "gemini":
-		return nil, fmt.Errorf("gemini backend not yet implemented (lands in P2)")
+		model := cfg.Model
+		if model == "" {
+			model = "gemini-embedding-001"
+		}
+		emb := NewGeminiEmbedder(model, cfg.APIKey, cfg.Dim)
+		if cfg.Endpoint != "" {
+			emb.WithBaseURL(cfg.Endpoint)
+		}
+		return emb, nil
 	case "voyage":
 		return nil, fmt.Errorf("voyage backend not yet implemented (lands in P7)")
 	case "openai":

--- a/pkg/vectors/registry.go
+++ b/pkg/vectors/registry.go
@@ -1,0 +1,48 @@
+package vectors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BackendConfig describes a chosen embedding backend in a form suitable
+// for building an Embedder. Populated by the setup wizard (P3) or by
+// reading flat config keys (embedding.backend, embedding.model, ...).
+type BackendConfig struct {
+	Backend  string // "ollama" | "gemini" | "voyage" | "openai" | "tfidf"
+	Model    string
+	Endpoint string // optional URL override
+	APIKey   string // plaintext; obtained by the caller from os.Getenv
+	Dim      int    // optional matryoshka truncation target (0 = native)
+}
+
+// BuildEmbedder materialises an Embedder from a BackendConfig.
+// Unknown backends return an error — callers should surface this to the
+// user as "run `claudemem setup` to configure an embedding backend."
+//
+// This is intentionally dumb: it just wires the right constructor. All
+// availability / API-key validation is deferred to Embedder.Available()
+// (called once after construction in the CLI layer).
+func BuildEmbedder(cfg BackendConfig) (Embedder, error) {
+	switch strings.ToLower(cfg.Backend) {
+	case "", "tfidf":
+		return NewTFIDFEmbedder(), nil
+
+	case "ollama":
+		emb := NewOllamaEmbedder(cfg.Model)
+		if cfg.Endpoint != "" {
+			emb.baseURL = cfg.Endpoint
+		}
+		return emb, nil
+
+	case "gemini":
+		return nil, fmt.Errorf("gemini backend not yet implemented (lands in P2)")
+	case "voyage":
+		return nil, fmt.Errorf("voyage backend not yet implemented (lands in P7)")
+	case "openai":
+		return nil, fmt.Errorf("openai backend not yet implemented (lands in P7)")
+
+	default:
+		return nil, fmt.Errorf("unknown embedding backend %q (known: tfidf, ollama, gemini, voyage, openai)", cfg.Backend)
+	}
+}

--- a/pkg/vectors/registry.go
+++ b/pkg/vectors/registry.go
@@ -46,9 +46,26 @@ func BuildEmbedder(cfg BackendConfig) (Embedder, error) {
 		}
 		return emb, nil
 	case "voyage":
-		return nil, fmt.Errorf("voyage backend not yet implemented (lands in P7)")
+		model := cfg.Model
+		if model == "" {
+			model = "voyage-3.5-lite"
+		}
+		emb := NewVoyageEmbedder(model, cfg.APIKey, cfg.Dim)
+		if cfg.Endpoint != "" {
+			emb.WithBaseURL(cfg.Endpoint)
+		}
+		return emb, nil
+
 	case "openai":
-		return nil, fmt.Errorf("openai backend not yet implemented (lands in P7)")
+		model := cfg.Model
+		if model == "" {
+			model = "text-embedding-3-small"
+		}
+		emb := NewOpenAIEmbedder(model, cfg.APIKey, cfg.Dim)
+		if cfg.Endpoint != "" {
+			emb.WithBaseURL(cfg.Endpoint)
+		}
+		return emb, nil
 
 	default:
 		return nil, fmt.Errorf("unknown embedding backend %q (known: tfidf, ollama, gemini, voyage, openai)", cfg.Backend)

--- a/pkg/vectors/store.go
+++ b/pkg/vectors/store.go
@@ -157,9 +157,14 @@ func (vs *VectorStore) createV22Schema() error {
 // every existing row with the backend that produced it and copy forward.
 // If vector_meta.index_backend is absent (pre-66c3fdc installs), we fall
 // back to a conservative ("tfidf", "tfidf") tuple — users can re-run
-// setup to re-embed with a real backend later.
+// setup to re-embed with a real backend later. A REAL DB error reading
+// the meta row is fatal: silently falling back to tfidf would mis-tag
+// MacBook's real Ollama embeddings.
 func (vs *VectorStore) migrateV21ToV22() error {
-	indexedBackend := readMeta(vs.db, "index_backend")
+	indexedBackend, err := readMeta(vs.db, "index_backend")
+	if err != nil {
+		return fmt.Errorf("read vector_meta.index_backend (required for migration): %w", err)
+	}
 	backend, model := parseBackendTuple(indexedBackend)
 
 	dim, err := firstRowDim(vs.db)
@@ -209,9 +214,24 @@ func parseBackendTuple(s string) (backend, model string) {
 	return s, s
 }
 
-func readMeta(db *sql.DB, key string) string {
+// readMeta returns the vector_meta value for a key. Distinguishes between
+// "not set" (returns empty string + nil) and "DB error" (returns empty +
+// error). The migration path MUST treat a real DB error as fatal because
+// silently returning "" would mis-tag every preserved vector as tfidf.
+func readMeta(db *sql.DB, key string) (string, error) {
 	var v string
-	db.QueryRow(`SELECT value FROM vector_meta WHERE key=?`, key).Scan(&v)
+	err := db.QueryRow(`SELECT value FROM vector_meta WHERE key=?`, key).Scan(&v)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return v, err
+}
+
+// readMetaOrEmpty is the forgiving variant for callers that don't care
+// about distinguishing "missing" from "error" (e.g. diagnostic health
+// output where we'd rather show "unknown" than abort).
+func readMetaOrEmpty(db *sql.DB, key string) string {
+	v, _ := readMeta(db, key)
 	return v
 }
 

--- a/pkg/vectors/store.go
+++ b/pkg/vectors/store.go
@@ -467,10 +467,17 @@ func (vs *VectorStore) loadTFIDFState(tf *TFIDFEmbedder) {
 	tf.Vectorizer().ImportState(&state)
 }
 
+// saveIndexBackend writes the active (backend:model) to vector_meta for
+// diagnostics only — per-doc metadata is the real source of truth now.
+// Errors are logged but not fatal: this runs after a successful commit
+// and a missed update just triggers a false-positive I5 warning.
 func (vs *VectorStore) saveIndexBackend() {
-	vs.db.Exec(
+	if _, err := vs.db.Exec(
 		`INSERT OR REPLACE INTO vector_meta (key, value) VALUES ('index_backend', ?)`,
-		vs.EmbeddingBackend())
+		vs.EmbeddingBackend()); err != nil {
+		fmt.Fprintf(os.Stderr,
+			"warn: could not update vector_meta.index_backend (%v)\n", err)
+	}
 }
 
 // --- helpers ---

--- a/pkg/vectors/store.go
+++ b/pkg/vectors/store.go
@@ -7,382 +7,482 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
+	"time"
 )
 
-// VectorStore manages embedding vectors stored in SQLite for semantic search.
-// Supports two backends: Ollama (real embeddings) and TF-IDF (fallback).
-// Ollama provides true semantic understanding; TF-IDF provides keyword similarity.
+// VectorStore manages per-document embedding vectors stored in SQLite.
+//
+// Schema (v22 — see docs/HYBRID_EMBEDDING_PLAN.md):
+//
+//	vectors(doc_id, backend, model, dim, vector, created_at) PK(doc_id, backend, model)
+//
+// Rationale for the composite key: two machines can share the same markdown
+// corpus via git and each embed with a different backend (e.g., web_dev uses
+// Gemini cloud; MacBook uses local Ollama). Both sets of vectors coexist in
+// the same table; each machine's searches filter by its active backend.
+// This also lets "switch backend" be an O(new rows) operation instead of
+// O(full reindex) — old rows stay queryable if you switch back.
+//
+// The store holds exactly one Embedder (the active backend). Read-path
+// failures (search) bubble up ErrBackendUnavailable to the caller — no
+// silent fallback. Write-path failures (index) are logged and skipped so
+// a down backend does not block note/session creation; `claudemem repair`
+// heals missing vectors later.
 type VectorStore struct {
-	db         *sql.DB
-	vectorizer *Vectorizer     // TF-IDF fallback
-	ollama     *OllamaEmbedder // Ollama primary (nil if unavailable)
-	useOllama  bool            // whether Ollama is active for this session
+	db       *sql.DB
+	embedder Embedder
 }
 
-// NewVectorStore creates a new VectorStore using the provided SQLite database.
-// Prioritizes Ollama for real semantic search; TF-IDF only when Ollama is unavailable.
-func NewVectorStore(db *sql.DB) (*VectorStore, error) {
-	vs := &VectorStore{db: db}
-
+// NewVectorStore creates a store bound to a specific Embedder. The embedder
+// is not pinged here; callers that care about freshness should call
+// embedder.Available() themselves before constructing the store.
+func NewVectorStore(db *sql.DB, embedder Embedder) (*VectorStore, error) {
+	if embedder == nil {
+		return nil, fmt.Errorf("vectors.NewVectorStore: embedder must not be nil (pass NewTFIDFEmbedder for tests)")
+	}
+	vs := &VectorStore{db: db, embedder: embedder}
 	if err := vs.initSchema(); err != nil {
 		return nil, fmt.Errorf("failed to init vector schema: %w", err)
 	}
-
-	// Try Ollama first — primary path
-	vs.tryInitOllama("")
-	if !vs.useOllama {
-		// Ollama unavailable — initialize TF-IDF as fallback
-		vs.vectorizer = NewVectorizer()
-		vs.loadVectorizerState()
+	// TF-IDF embedders persist their vocabulary in vector_meta; restore it.
+	if tf, ok := embedder.(*TFIDFEmbedder); ok {
+		vs.loadTFIDFState(tf)
 	}
-
-	// Check backend consistency: warn if index was built with a different backend
-	vs.checkBackendConsistency()
-
 	return vs, nil
 }
 
-// NewVectorStoreWithModel creates a VectorStore with a specific Ollama model.
-func NewVectorStoreWithModel(db *sql.DB, model string) (*VectorStore, error) {
-	vs := &VectorStore{db: db}
+// Embedder returns the active backend. Exposed so callers (e.g., health
+// checks, CLI "stats" output) can inspect Name()/Model()/Dimensions()
+// without reaching into the store's internals.
+func (vs *VectorStore) Embedder() Embedder { return vs.embedder }
 
-	if err := vs.initSchema(); err != nil {
-		return nil, fmt.Errorf("failed to init vector schema: %w", err)
-	}
-
-	vs.tryInitOllama(model)
-	if !vs.useOllama {
-		vs.vectorizer = NewVectorizer()
-		vs.loadVectorizerState()
-	}
-
-	vs.checkBackendConsistency()
-
-	return vs, nil
-}
-
-// tryInitOllama attempts to connect to a local Ollama instance.
-func (vs *VectorStore) tryInitOllama(model string) {
-	embedder := NewOllamaEmbedder(model)
-	if embedder.Available() {
-		vs.ollama = embedder
-		vs.useOllama = true
-	}
-}
-
-// UsingOllama returns true if Ollama embeddings are active.
-func (vs *VectorStore) UsingOllama() bool {
-	return vs.useOllama
-}
-
-// EmbeddingBackend returns "ollama" or "tfidf" to indicate active backend.
+// EmbeddingBackend returns the "backend:model" tuple string used in
+// diagnostic output. Preserved for compatibility with existing callers
+// (filestore_vectors.go, stats command).
 func (vs *VectorStore) EmbeddingBackend() string {
-	if vs.useOllama {
-		return "ollama:" + vs.ollama.Model()
-	}
-	return "tfidf"
+	return vs.embedder.Name() + ":" + vs.embedder.Model()
 }
 
-// initSchema creates the vector storage tables.
+// initSchema creates or migrates the vectors + vector_meta tables.
+// On first run with the old v21 schema (id, vector), this migrates rows
+// in place, tagging them with whatever backend previously produced them.
+// This preserves MacBook's real Ollama vectors across the upgrade.
 func (vs *VectorStore) initSchema() error {
-	schema := `
-	CREATE TABLE IF NOT EXISTS vectors (
-		id TEXT PRIMARY KEY,
-		vector BLOB NOT NULL
-	);
-	CREATE TABLE IF NOT EXISTS vector_meta (
-		key TEXT PRIMARY KEY,
-		value TEXT NOT NULL
-	);`
-
-	_, err := vs.db.Exec(schema)
-	return err
-}
-
-// IndexDocument adds or updates a document's vector in the store.
-// Uses a single backend per session: Ollama when available, TF-IDF otherwise.
-// Never mixes backends — this prevents dimension mismatches that make documents invisible.
-func (vs *VectorStore) IndexDocument(id, text string) error {
-	var vec []float32
-	var err error
-
-	if vs.useOllama {
-		// Truncate to fit model context window, then embed
-		vec, err = vs.ollama.Embed(TruncateForEmbed(text))
-		if err != nil {
-			// Ollama failed even after truncation — skip this document for semantic search.
-			// Better absent than invisible (TF-IDF would create wrong-dimension vector).
-			fmt.Fprintf(os.Stderr, "ollama embed failed for %s (skipping): %v\n", id[:8], err)
-			return nil
-		}
-	} else {
-		vec = vs.vectorizer.Vectorize(text)
+	// vector_meta is stable across versions
+	if _, err := vs.db.Exec(`
+		CREATE TABLE IF NOT EXISTS vector_meta (
+			key TEXT PRIMARY KEY,
+			value TEXT NOT NULL
+		)`); err != nil {
+		return err
 	}
 
-	if vec == nil {
+	kind, err := detectVectorsSchema(vs.db)
+	if err != nil {
+		return err
+	}
+	switch kind {
+	case schemaNone:
+		return vs.createV22Schema()
+	case schemaV21:
+		return vs.migrateV21ToV22()
+	case schemaV22:
 		return nil
 	}
+	return fmt.Errorf("unknown vectors schema kind %d", kind)
+}
 
-	blob := vectorToBlob(vec)
+type vectorsSchemaKind int
+
+const (
+	schemaNone vectorsSchemaKind = iota
+	schemaV21                    // (id, vector)
+	schemaV22                    // (doc_id, backend, model, dim, vector, created_at)
+)
+
+func detectVectorsSchema(db *sql.DB) (vectorsSchemaKind, error) {
+	rows, err := db.Query(`PRAGMA table_info(vectors)`)
+	if err != nil {
+		return schemaNone, fmt.Errorf("pragma table_info: %w", err)
+	}
+	defer rows.Close()
+	var cols []string
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, typ string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dflt, &pk); err != nil {
+			return schemaNone, err
+		}
+		cols = append(cols, name)
+	}
+	if len(cols) == 0 {
+		return schemaNone, nil
+	}
+	has := map[string]bool{}
+	for _, c := range cols {
+		has[c] = true
+	}
+	if has["doc_id"] && has["backend"] && has["model"] {
+		return schemaV22, nil
+	}
+	if has["id"] && has["vector"] {
+		return schemaV21, nil
+	}
+	return schemaNone, fmt.Errorf("vectors table has unexpected columns: %v", cols)
+}
+
+const v22Schema = `
+CREATE TABLE vectors (
+	doc_id     TEXT    NOT NULL,
+	backend    TEXT    NOT NULL,
+	model      TEXT    NOT NULL,
+	dim        INTEGER NOT NULL,
+	vector     BLOB    NOT NULL,
+	created_at TEXT    NOT NULL,
+	PRIMARY KEY (doc_id, backend, model)
+);
+CREATE INDEX IF NOT EXISTS idx_vectors_backend ON vectors(backend, model);
+CREATE INDEX IF NOT EXISTS idx_vectors_doc ON vectors(doc_id);
+`
+
+func (vs *VectorStore) createV22Schema() error {
+	_, err := vs.db.Exec(v22Schema)
+	return err
+}
+
+// migrateV21ToV22 is the preservation-first migration. Rather than dropping
+// the old flat (id, vector) table and forcing a costly re-embed, we tag
+// every existing row with the backend that produced it and copy forward.
+// If vector_meta.index_backend is absent (pre-66c3fdc installs), we fall
+// back to a conservative ("tfidf", "tfidf") tuple — users can re-run
+// setup to re-embed with a real backend later.
+func (vs *VectorStore) migrateV21ToV22() error {
+	indexedBackend := readMeta(vs.db, "index_backend")
+	backend, model := parseBackendTuple(indexedBackend)
+
+	dim, err := firstRowDim(vs.db)
+	if err != nil {
+		return fmt.Errorf("inspect existing vector dim: %w", err)
+	}
+
+	tx, err := vs.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`ALTER TABLE vectors RENAME TO vectors_v21`); err != nil {
+		return fmt.Errorf("rename v21: %w", err)
+	}
+	if _, err := tx.Exec(v22Schema); err != nil {
+		return fmt.Errorf("create v22: %w", err)
+	}
+	if _, err := tx.Exec(`
+		INSERT INTO vectors (doc_id, backend, model, dim, vector, created_at)
+		SELECT id, ?, ?, ?, vector, ? FROM vectors_v21`,
+		backend, model, dim, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("copy rows: %w", err)
+	}
+	if _, err := tx.Exec(`DROP TABLE vectors_v21`); err != nil {
+		return fmt.Errorf("drop v21: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr,
+		"claudemem: migrated vectors table from v21 to v22 (tagged %d existing rows as %s:%s @%dd)\n",
+		countRows(vs.db, "vectors"), backend, model, dim)
+	return nil
+}
+
+// parseBackendTuple splits "ollama:nomic-embed-text" into ("ollama",
+// "nomic-embed-text"). A bare string (legacy "tfidf") gets duplicated.
+func parseBackendTuple(s string) (backend, model string) {
+	if s == "" {
+		return "tfidf", "tfidf"
+	}
+	if i := strings.Index(s, ":"); i > 0 {
+		return s[:i], s[i+1:]
+	}
+	return s, s
+}
+
+func readMeta(db *sql.DB, key string) string {
+	var v string
+	db.QueryRow(`SELECT value FROM vector_meta WHERE key=?`, key).Scan(&v)
+	return v
+}
+
+func firstRowDim(db *sql.DB) (int, error) {
+	var blob []byte
+	err := db.QueryRow(`SELECT vector FROM vectors LIMIT 1`).Scan(&blob)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return len(blob) / 4, nil
+}
+
+func countRows(db *sql.DB, table string) int {
+	var n int
+	db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&n)
+	return n
+}
+
+// IndexDocument adds/updates a single document's vector under the active
+// (backend, model). Forgiving by design: embed failures are logged and
+// skipped so a down backend does not block the write path. The health
+// subsystem (P5) can heal missing rows later via `claudemem repair`.
+func (vs *VectorStore) IndexDocument(id, text string) error {
+	vec, err := vs.embedder.Embed(TruncateForEmbed(text), InputTypeDocument)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "index %s skipped (%s:%s embed failed: %v) — run `claudemem repair` to retry\n",
+			shortID(id), vs.embedder.Name(), vs.embedder.Model(), err)
+		return nil
+	}
+	if vec == nil {
+		return nil // TF-IDF returns nil before vocabulary is built
+	}
+
 	_, err = vs.db.Exec(`
-		INSERT OR REPLACE INTO vectors (id, vector)
-		VALUES (?, ?)
-	`, id, blob)
+		INSERT OR REPLACE INTO vectors
+			(doc_id, backend, model, dim, vector, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		id, vs.embedder.Name(), vs.embedder.Model(), len(vec),
+		vectorToBlob(vec), time.Now().UTC().Format(time.RFC3339))
 	return err
 }
 
-// RemoveDocument removes a document's vector from the store.
+// RemoveDocument removes ALL vectors for a given doc (across any backends
+// that have rows for it). This matches the filesystem truth — if a markdown
+// note is deleted, its embeddings are garbage regardless of backend.
 func (vs *VectorStore) RemoveDocument(id string) error {
-	_, err := vs.db.Exec(`DELETE FROM vectors WHERE id = ?`, id)
+	_, err := vs.db.Exec(`DELETE FROM vectors WHERE doc_id = ?`, id)
 	return err
 }
 
-// SearchResult represents a semantic search result with similarity score.
+// SearchResult is a single semantic search hit.
 type SearchResult struct {
 	ID         string  `json:"id"`
 	Similarity float32 `json:"similarity"`
 }
 
-// Search performs semantic search by finding the most similar documents.
-// Uses Ollama embeddings if available, falls back to TF-IDF cosine similarity.
-// Returns up to limit results sorted by similarity (highest first).
+// Search performs semantic search over vectors produced by the ACTIVE
+// (backend, model). Read-path contract: if the backend is unreachable,
+// this propagates the error to the caller (no silent fallback). The CLI
+// layer translates it into fail-loud / interactive recovery (P4).
 func (vs *VectorStore) Search(query string, limit int) ([]SearchResult, error) {
 	if limit <= 0 {
 		limit = 20
 	}
 
-	var queryVec []float32
-	if vs.useOllama {
-		var err error
-		queryVec, err = vs.ollama.Embed(TruncateForEmbed(query))
-		if err != nil {
-			// Ollama failed for query — cannot search (mixing backends would miss documents)
-			return nil, nil
-		}
-	} else {
-		queryVec = vs.vectorizer.Vectorize(query)
+	queryVec, err := vs.embedder.Embed(TruncateForEmbed(query), InputTypeQuery)
+	if err != nil {
+		return nil, err // bubble up; do NOT degrade
 	}
 	if queryVec == nil {
 		return nil, nil
 	}
 
-	// Scan all vectors and compute similarity
-	// For the typical claudemem scale (<10K docs), brute-force is fine.
-	rows, err := vs.db.Query(`SELECT id, vector FROM vectors`)
+	rows, err := vs.db.Query(`
+		SELECT doc_id, vector FROM vectors
+		WHERE backend = ? AND model = ?`,
+		vs.embedder.Name(), vs.embedder.Model())
 	if err != nil {
-		return nil, fmt.Errorf("failed to query vectors: %w", err)
+		return nil, fmt.Errorf("query vectors: %w", err)
 	}
 	defer rows.Close()
 
 	var results []SearchResult
+	queryDim := len(queryVec)
 	for rows.Next() {
 		var id string
 		var blob []byte
 		if err := rows.Scan(&id, &blob); err != nil {
 			continue
 		}
-
 		docVec := blobToVector(blob)
-		if len(docVec) != len(queryVec) {
-			continue // dimension mismatch (stale vector from old vocab), skip
+		if len(docVec) != queryDim {
+			continue
 		}
-
-		similarity := CosineSimilarity(queryVec, docVec)
-		if similarity > 0.01 { // filter out near-zero matches
-			results = append(results, SearchResult{
-				ID:         id,
-				Similarity: similarity,
-			})
+		sim := CosineSimilarity(queryVec, docVec)
+		if sim > 0.01 {
+			results = append(results, SearchResult{ID: id, Similarity: sim})
 		}
 	}
-
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("rows iteration error: %w", err)
+		return nil, fmt.Errorf("rows iter: %w", err)
 	}
 
-	// Sort by similarity descending
 	sortResultsBySimilarity(results)
-
-	// Apply limit
 	if len(results) > limit {
 		results = results[:limit]
 	}
-
 	return results, nil
 }
 
-// RebuildIndex rebuilds the entire vector index from the provided documents.
-// Uses Ollama batch embedding if available, falls back to TF-IDF.
-func (vs *VectorStore) RebuildIndex(documents []Document) error {
-	// Clear existing vectors
-	if _, err := vs.db.Exec(`DELETE FROM vectors`); err != nil {
-		return fmt.Errorf("failed to clear vectors: %w", err)
-	}
-
-	if len(documents) == 0 {
-		return nil
-	}
-
-	tx, err := vs.db.Begin()
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer tx.Rollback()
-
-	stmt, err := tx.Prepare(`INSERT INTO vectors (id, vector) VALUES (?, ?)`)
-	if err != nil {
-		return fmt.Errorf("failed to prepare statement: %w", err)
-	}
-	defer stmt.Close()
-
-	if vs.useOllama {
-		// Ollama path: batch embed in chunks of 50
-		batchSize := 50
-		for i := 0; i < len(documents); i += batchSize {
-			end := i + batchSize
-			if end > len(documents) {
-				end = len(documents)
-			}
-			batch := documents[i:end]
-
-			texts := make([]string, len(batch))
-			for j, doc := range batch {
-				texts[j] = TruncateForEmbed(doc.Text)
-			}
-
-			embeddings, embErr := vs.ollama.EmbedBatch(texts)
-			if embErr != nil {
-				// Batch failed — retry individually with truncation (never mix in TF-IDF)
-				fmt.Fprintf(os.Stderr, "ollama batch failed at offset %d, retrying per-doc with truncation: %v\n", i, embErr)
-				for _, doc := range batch {
-					vec, singleErr := vs.ollama.Embed(TruncateForEmbed(doc.Text))
-					if singleErr != nil {
-						// Still failed after truncation — skip (better absent than wrong-dimension)
-						fmt.Fprintf(os.Stderr, "  skipping %s: %v\n", doc.ID[:8], singleErr)
-						continue
-					}
-					blob := vectorToBlob(vec)
-					if _, err := stmt.Exec(doc.ID, blob); err != nil {
-						return fmt.Errorf("failed to insert vector for %s: %w", doc.ID, err)
-					}
-				}
-				continue
-			}
-
-			for j, doc := range batch {
-				blob := vectorToBlob(embeddings[j])
-				if _, err := stmt.Exec(doc.ID, blob); err != nil {
-					return fmt.Errorf("failed to insert vector for %s: %w", doc.ID, err)
-				}
-			}
-		}
-	} else {
-		// TF-IDF fallback path
-		corpus := make([]string, len(documents))
-		for i, doc := range documents {
-			corpus[i] = doc.Text
-		}
-		vs.vectorizer.BuildVocab(corpus)
-
-		for _, doc := range documents {
-			vec := vs.vectorizer.Vectorize(doc.Text)
-			if vec == nil {
-				continue
-			}
-			blob := vectorToBlob(vec)
-			if _, err := stmt.Exec(doc.ID, blob); err != nil {
-				return fmt.Errorf("failed to insert vector for %s: %w", doc.ID, err)
-			}
-		}
-
-	}
-
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit: %w", err)
-	}
-
-	// Persist backend-specific state (after commit, outside transaction)
-	if !vs.useOllama && vs.vectorizer != nil {
-		if err := vs.saveVectorizerState(); err != nil {
-			return err
-		}
-	}
-
-	// Record which backend was used to build this index
-	vs.saveIndexBackend()
-
-	return nil
-}
-
-// Count returns the number of vectors in the store.
-func (vs *VectorStore) Count() (int, error) {
-	var count int
-	err := vs.db.QueryRow(`SELECT COUNT(*) FROM vectors`).Scan(&count)
-	return count, err
-}
-
-// Document represents a document to be indexed.
+// Document is the input shape for RebuildIndex.
 type Document struct {
 	ID   string
 	Text string
 }
 
-// saveVectorizerState persists the vectorizer state to the database.
-func (vs *VectorStore) saveVectorizerState() error {
-	state := vs.vectorizer.ExportState()
-	data, err := json.Marshal(state)
-	if err != nil {
-		return fmt.Errorf("failed to marshal vectorizer state: %w", err)
+// RebuildIndex embeds every document with the ACTIVE backend+model, tagging
+// each row accordingly. Existing rows under OTHER (backend, model) tuples
+// are preserved (cross-machine / switch-back use cases). Only rows under
+// the CURRENT backend+model are wiped and rebuilt.
+//
+// For TF-IDF embedders, this also rebuilds the vocabulary from the corpus.
+func (vs *VectorStore) RebuildIndex(documents []Document) error {
+	if tf, ok := vs.embedder.(*TFIDFEmbedder); ok {
+		corpus := make([]string, len(documents))
+		for i, d := range documents {
+			corpus[i] = d.Text
+		}
+		tf.BuildVocab(corpus)
 	}
 
+	tx, err := vs.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`DELETE FROM vectors WHERE backend = ? AND model = ?`,
+		vs.embedder.Name(), vs.embedder.Model()); err != nil {
+		return fmt.Errorf("clear active backend rows: %w", err)
+	}
+
+	if len(documents) == 0 {
+		return tx.Commit()
+	}
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO vectors (doc_id, backend, model, dim, vector, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	const batchSize = 50
+	now := time.Now().UTC().Format(time.RFC3339)
+	backend, model := vs.embedder.Name(), vs.embedder.Model()
+
+	for i := 0; i < len(documents); i += batchSize {
+		end := i + batchSize
+		if end > len(documents) {
+			end = len(documents)
+		}
+		batch := documents[i:end]
+
+		texts := make([]string, len(batch))
+		for j, d := range batch {
+			texts[j] = TruncateForEmbed(d.Text)
+		}
+		embeddings, err := vs.embedder.EmbedBatch(texts, InputTypeDocument)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"embed batch failed at offset %d (%s:%s): %v — retrying per-doc\n",
+				i, backend, model, err)
+			for _, d := range batch {
+				vec, singleErr := vs.embedder.Embed(TruncateForEmbed(d.Text), InputTypeDocument)
+				if singleErr != nil || vec == nil {
+					fmt.Fprintf(os.Stderr, "  skip %s: %v\n", shortID(d.ID), singleErr)
+					continue
+				}
+				if _, err := stmt.Exec(d.ID, backend, model, len(vec), vectorToBlob(vec), now); err != nil {
+					return fmt.Errorf("insert vector for %s: %w", d.ID, err)
+				}
+			}
+			continue
+		}
+
+		for j, d := range batch {
+			vec := embeddings[j]
+			if vec == nil {
+				continue
+			}
+			if _, err := stmt.Exec(d.ID, backend, model, len(vec), vectorToBlob(vec), now); err != nil {
+				return fmt.Errorf("insert vector for %s: %w", d.ID, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
+	}
+
+	if tf, ok := vs.embedder.(*TFIDFEmbedder); ok {
+		vs.saveTFIDFState(tf)
+	}
+	vs.saveIndexBackend()
+	return nil
+}
+
+// Count returns the number of vector rows under the active (backend, model).
+func (vs *VectorStore) Count() (int, error) {
+	var n int
+	err := vs.db.QueryRow(`
+		SELECT COUNT(*) FROM vectors WHERE backend = ? AND model = ?`,
+		vs.embedder.Name(), vs.embedder.Model()).Scan(&n)
+	return n, err
+}
+
+// CountAll returns the total number of vector rows across all backends.
+func (vs *VectorStore) CountAll() (int, error) {
+	var n int
+	err := vs.db.QueryRow(`SELECT COUNT(*) FROM vectors`).Scan(&n)
+	return n, err
+}
+
+// saveTFIDFState persists the TF-IDF vocabulary to vector_meta.
+func (vs *VectorStore) saveTFIDFState(tf *TFIDFEmbedder) error {
+	state := tf.Vectorizer().ExportState()
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("marshal tfidf state: %w", err)
+	}
 	_, err = vs.db.Exec(`
 		INSERT OR REPLACE INTO vector_meta (key, value)
-		VALUES ('vectorizer_state', ?)
-	`, string(data))
+		VALUES ('vectorizer_state', ?)`, string(data))
 	return err
 }
 
-// loadVectorizerState restores the vectorizer state from the database.
-func (vs *VectorStore) loadVectorizerState() {
+func (vs *VectorStore) loadTFIDFState(tf *TFIDFEmbedder) {
 	var data string
-	err := vs.db.QueryRow(`
+	if err := vs.db.QueryRow(`
 		SELECT value FROM vector_meta WHERE key = 'vectorizer_state'
-	`).Scan(&data)
-	if err != nil {
-		return // no state yet, that's fine
+	`).Scan(&data); err != nil {
+		return
 	}
-
 	var state VectorizerState
 	if err := json.Unmarshal([]byte(data), &state); err != nil {
-		return // corrupted state, will be rebuilt on next reindex
+		return
 	}
-
-	vs.vectorizer.ImportState(&state)
+	tf.Vectorizer().ImportState(&state)
 }
 
-// saveIndexBackend records which embedding backend was used to build the current index.
 func (vs *VectorStore) saveIndexBackend() {
-	backend := vs.EmbeddingBackend()
-	vs.db.Exec(`INSERT OR REPLACE INTO vector_meta (key, value) VALUES ('index_backend', ?)`, backend)
+	vs.db.Exec(
+		`INSERT OR REPLACE INTO vector_meta (key, value) VALUES ('index_backend', ?)`,
+		vs.EmbeddingBackend())
 }
 
-// checkBackendConsistency warns if the current backend doesn't match the indexed backend.
-// This catches the "Ollama was running, now it's down" scenario where semantic search
-// would silently return nothing due to dimension mismatch.
-func (vs *VectorStore) checkBackendConsistency() {
-	var indexedBackend string
-	err := vs.db.QueryRow(`SELECT value FROM vector_meta WHERE key = 'index_backend'`).Scan(&indexedBackend)
-	if err != nil {
-		return // no backend recorded yet (first run), nothing to check
-	}
+// --- helpers ---
 
-	currentBackend := vs.EmbeddingBackend()
-	if indexedBackend != currentBackend {
-		fmt.Fprintf(os.Stderr, "warning: vector index built with %s but current backend is %s — semantic search may be degraded, run 'claudemem reindex --vectors' to rebuild\n", indexedBackend, currentBackend)
+func shortID(id string) string {
+	if len(id) >= 8 {
+		return id[:8]
 	}
+	return id
 }
 
-// vectorToBlob converts a float32 vector to a byte slice (little-endian IEEE 754).
+// vectorToBlob converts a float32 vector to a little-endian IEEE 754 byte slice.
 func vectorToBlob(vec []float32) []byte {
 	buf := make([]byte, len(vec)*4)
 	for i, v := range vec {
@@ -391,7 +491,6 @@ func vectorToBlob(vec []float32) []byte {
 	return buf
 }
 
-// blobToVector converts a byte slice back to a float32 vector.
 func blobToVector(blob []byte) []float32 {
 	if len(blob)%4 != 0 {
 		return nil
@@ -403,7 +502,6 @@ func blobToVector(blob []byte) []float32 {
 	return vec
 }
 
-// sortResultsBySimilarity sorts results by similarity descending (insertion sort).
 func sortResultsBySimilarity(results []SearchResult) {
 	for i := 1; i < len(results); i++ {
 		for j := i; j > 0 && results[j].Similarity > results[j-1].Similarity; j-- {

--- a/pkg/vectors/store_test.go
+++ b/pkg/vectors/store_test.go
@@ -20,7 +20,7 @@ func TestNewVectorStore(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	vs, err := NewVectorStore(db)
+	vs, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore failed: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestVectorStore_RebuildIndex(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	vs, err := NewVectorStore(db)
+	vs, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore failed: %v", err)
 	}
@@ -69,7 +69,7 @@ func TestVectorStore_Search(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	vs, err := NewVectorStore(db)
+	vs, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore failed: %v", err)
 	}
@@ -117,7 +117,7 @@ func TestVectorStore_Search_EmptyIndex(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	vs, err := NewVectorStore(db)
+	vs, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore failed: %v", err)
 	}
@@ -135,7 +135,7 @@ func TestVectorStore_RemoveDocument(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 
-	vs, err := NewVectorStore(db)
+	vs, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore failed: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestVectorStore_PersistState(t *testing.T) {
 	defer db.Close()
 
 	// Build index and persist state
-	vs1, err := NewVectorStore(db)
+	vs1, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore failed: %v", err)
 	}
@@ -186,7 +186,7 @@ func TestVectorStore_PersistState(t *testing.T) {
 	}
 
 	// Create new VectorStore on the same DB — should load persisted state
-	vs2, err := NewVectorStore(db)
+	vs2, err := NewVectorStore(db, NewTFIDFEmbedder())
 	if err != nil {
 		t.Fatalf("NewVectorStore (reload) failed: %v", err)
 	}

--- a/pkg/vectors/tfidf_embedder.go
+++ b/pkg/vectors/tfidf_embedder.go
@@ -1,0 +1,73 @@
+package vectors
+
+// TFIDFEmbedder adapts the TF-IDF Vectorizer to the Embedder interface.
+//
+// TF-IDF is intentionally a first-class backend choice, not a silent fallback.
+// It is useful for:
+//   - airgapped environments (no daemon, no API key required)
+//   - CI / automated tests
+//   - users who prefer keyword-ish semantic search without runtime dependencies
+//
+// The underlying Vectorizer is built from the indexed corpus, so dimensions
+// are determined by vocabulary size and only stabilize after RebuildIndex
+// is called. Until then, Dimensions() returns 0.
+type TFIDFEmbedder struct {
+	vectorizer *Vectorizer
+}
+
+// NewTFIDFEmbedder creates a TF-IDF-backed Embedder.
+func NewTFIDFEmbedder() *TFIDFEmbedder {
+	return &TFIDFEmbedder{vectorizer: NewVectorizer()}
+}
+
+// WrapVectorizer builds a TFIDFEmbedder around an existing Vectorizer.
+// Used when loading persisted state from the DB.
+func WrapVectorizer(v *Vectorizer) *TFIDFEmbedder {
+	return &TFIDFEmbedder{vectorizer: v}
+}
+
+// Vectorizer returns the underlying Vectorizer for persistence code that
+// needs to export/import state. Intentionally package-private concept
+// exposed only via this explicit accessor.
+func (e *TFIDFEmbedder) Vectorizer() *Vectorizer {
+	return e.vectorizer
+}
+
+// Available always returns nil — TF-IDF has no external dependency.
+func (e *TFIDFEmbedder) Available() error {
+	return nil
+}
+
+// Embed produces a TF-IDF vector. Returns nil (not an error) if vocabulary
+// is empty; callers should trigger a RebuildIndex in that case.
+func (e *TFIDFEmbedder) Embed(text string, _ InputType) ([]float32, error) {
+	vec := e.vectorizer.Vectorize(text)
+	return vec, nil
+}
+
+// EmbedBatch processes each text individually (TF-IDF has no batch speedup).
+func (e *TFIDFEmbedder) EmbedBatch(texts []string, _ InputType) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		out[i] = e.vectorizer.Vectorize(t)
+	}
+	return out, nil
+}
+
+// Name returns "tfidf".
+func (e *TFIDFEmbedder) Name() string { return "tfidf" }
+
+// Model returns "tfidf" (no concept of model variants).
+func (e *TFIDFEmbedder) Model() string { return "tfidf" }
+
+// Dimensions returns the current vocabulary size.
+// Returns 0 before the first BuildVocab.
+func (e *TFIDFEmbedder) Dimensions() int {
+	return e.vectorizer.VocabSize()
+}
+
+// BuildVocab rebuilds the vocabulary from a fresh corpus.
+// Called from RebuildIndex to reset the TF-IDF state before re-embedding.
+func (e *TFIDFEmbedder) BuildVocab(corpus []string) {
+	e.vectorizer.BuildVocab(corpus)
+}

--- a/pkg/vectors/voyage.go
+++ b/pkg/vectors/voyage.go
@@ -1,0 +1,174 @@
+package vectors
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// VoyageEmbedder uses Voyage AI's v1/embeddings endpoint.
+//
+// Voyage-3.5-lite is the April 2026 budget cloud pick — $0.02/M tokens
+// with 200M free tokens for new accounts (effectively free for most
+// claudemem users). 1024 native dim, 32K input limit, 128 inputs/batch.
+// Supports input_type=document|query (use the right one per-call for
+// retrieval quality).
+//
+// See: https://docs.voyageai.com/reference/embeddings-api
+type VoyageEmbedder struct {
+	baseURL string
+	model   string
+	apiKey  string
+	dim     int
+	client  *http.Client
+}
+
+const DefaultVoyageBaseURL = "https://api.voyageai.com/v1"
+
+func NewVoyageEmbedder(model, apiKey string, dim int) *VoyageEmbedder {
+	if model == "" {
+		model = "voyage-3.5-lite"
+	}
+	return &VoyageEmbedder{
+		baseURL: DefaultVoyageBaseURL,
+		model:   model,
+		apiKey:  apiKey,
+		dim:     dim,
+		client:  &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (v *VoyageEmbedder) WithBaseURL(u string) *VoyageEmbedder {
+	v.baseURL = u
+	return v
+}
+
+func (v *VoyageEmbedder) Name() string  { return "voyage" }
+func (v *VoyageEmbedder) Model() string { return v.model }
+func (v *VoyageEmbedder) Dimensions() int {
+	if v.dim > 0 {
+		return v.dim
+	}
+	return 1024 // voyage-3.5-lite native
+}
+
+func (v *VoyageEmbedder) Available() error {
+	if v.apiKey == "" {
+		return &ErrBackendUnavailable{
+			Backend: "voyage:" + v.model,
+			Cause:   fmt.Errorf("no API key configured"),
+			Hint:    "export VOYAGE_API_KEY=... (or run `claudemem setup`)",
+		}
+	}
+	// Voyage doesn't expose a cheap metadata endpoint; do a minimal embed
+	// of a single short string as the health probe.
+	_, err := v.Embed("health", InputTypeQuery)
+	if err != nil {
+		return &ErrBackendUnavailable{
+			Backend: "voyage:" + v.model,
+			Cause:   err,
+			Hint:    "check VOYAGE_API_KEY is valid at https://dash.voyageai.com/api-keys",
+		}
+	}
+	return nil
+}
+
+func (v *VoyageEmbedder) Embed(text string, t InputType) ([]float32, error) {
+	vecs, err := v.EmbedBatch([]string{text}, t)
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 {
+		return nil, fmt.Errorf("voyage returned no embeddings")
+	}
+	return vecs[0], nil
+}
+
+func (v *VoyageEmbedder) EmbedBatch(texts []string, t InputType) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	const max = 128 // Voyage batch limit
+	out := make([][]float32, 0, len(texts))
+	for i := 0; i < len(texts); i += max {
+		end := i + max
+		if end > len(texts) {
+			end = len(texts)
+		}
+		chunk := texts[i:end]
+		vecs, err := v.embedBatchOne(chunk, t)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (v *VoyageEmbedder) embedBatchOne(texts []string, t InputType) ([][]float32, error) {
+	body := voyageRequest{
+		Input:           texts,
+		Model:           v.model,
+		InputType:       voyageInputType(t),
+		OutputDimension: v.dim, // omitempty — 0 keeps native
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", v.baseURL+"/embeddings", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+v.apiKey)
+	resp, err := v.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("voyage request: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("voyage HTTP %d: %s", resp.StatusCode, string(b))
+	}
+	var parsed voyageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode voyage: %w", err)
+	}
+	out := make([][]float32, len(parsed.Data))
+	for _, d := range parsed.Data {
+		if d.Index < 0 || d.Index >= len(out) {
+			return nil, fmt.Errorf("voyage returned out-of-range index %d", d.Index)
+		}
+		out[d.Index] = d.Embedding
+	}
+	return out, nil
+}
+
+func voyageInputType(t InputType) string {
+	switch t {
+	case InputTypeQuery:
+		return "query"
+	case InputTypeDocument:
+		return "document"
+	default:
+		return "document"
+	}
+}
+
+type voyageRequest struct {
+	Input           []string `json:"input"`
+	Model           string   `json:"model"`
+	InputType       string   `json:"input_type,omitempty"`
+	OutputDimension int      `json:"output_dimension,omitempty"`
+}
+
+type voyageResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+}

--- a/pkg/vectors/voyage.go
+++ b/pkg/vectors/voyage.go
@@ -138,7 +138,15 @@ func (v *VoyageEmbedder) embedBatchOne(texts []string, t InputType) ([][]float32
 	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
 		return nil, fmt.Errorf("decode voyage: %w", err)
 	}
-	out := make([][]float32, len(parsed.Data))
+	// Defensive: size the output by INPUT length, not response length. A
+	// partial response (rate-limited, mid-batch failure) can otherwise
+	// panic downstream RebuildIndex which does `embeddings[j]` assuming
+	// response length == batch length. Matches Gemini's guard.
+	if len(parsed.Data) != len(texts) {
+		return nil, fmt.Errorf("voyage returned %d embeddings for %d inputs (partial response not supported)",
+			len(parsed.Data), len(texts))
+	}
+	out := make([][]float32, len(texts))
 	for _, d := range parsed.Data {
 		if d.Index < 0 || d.Index >= len(out) {
 			return nil, fmt.Errorf("voyage returned out-of-range index %d", d.Index)

--- a/pkg/vectors/voyage.go
+++ b/pkg/vectors/voyage.go
@@ -55,22 +55,19 @@ func (v *VoyageEmbedder) Dimensions() int {
 	return 1024 // voyage-3.5-lite native
 }
 
+// Available does a LIGHTWEIGHT check: api_key present. We intentionally
+// do NOT probe the API here because Voyage has no cheap metadata
+// endpoint — a real probe would burn billed tokens on every CLI start.
+// If the key is invalid, the first real Embed call surfaces it as an
+// ErrBackendUnavailable via the same code path; we trade precision of
+// error timing for zero idle cost. Matches the "embedder is not pinged
+// at construct time" design comment in store.go.
 func (v *VoyageEmbedder) Available() error {
 	if v.apiKey == "" {
 		return &ErrBackendUnavailable{
 			Backend: "voyage:" + v.model,
 			Cause:   fmt.Errorf("no API key configured"),
 			Hint:    "export VOYAGE_API_KEY=... (or run `claudemem setup`)",
-		}
-	}
-	// Voyage doesn't expose a cheap metadata endpoint; do a minimal embed
-	// of a single short string as the health probe.
-	_, err := v.Embed("health", InputTypeQuery)
-	if err != nil {
-		return &ErrBackendUnavailable{
-			Backend: "voyage:" + v.model,
-			Cause:   err,
-			Hint:    "check VOYAGE_API_KEY is valid at https://dash.voyageai.com/api-keys",
 		}
 	}
 	return nil

--- a/skills/claudemem/SKILL.md
+++ b/skills/claudemem/SKILL.md
@@ -5,7 +5,8 @@ description: >
   Provides full-text search with faceted filters, code structure analysis, and
   bidirectional cross-referencing between notes and sessions. Use when saving
   knowledge for future sessions, recalling past work, searching stored context,
-  wrapping up a session, or analyzing code structure. All local, zero network.
+  wrapping up a session, or analyzing code structure. Default: local, zero network.
+  Cloud embedding backends (Gemini, Voyage, OpenAI) are opt-in via `claudemem setup`.
 ---
 
 # claudemem — Persistent Memory for AI Agents


### PR DESCRIPTION
## Summary

Refactors claudemem from a concrete Ollama/TF-IDF fallback into a pluggable multi-backend memory system with explicit setup UX, cross-machine git sync, and health/repair tooling. 11 commits, +4,800/-530 LOC, 30+ tests.

**Design rules (non-negotiable, from docs/HYBRID_EMBEDDING_PLAN.md)**:
1. No silent fallback — user explicitly picks a backend; failures surface with recovery instructions (never degrade to a lesser backend silently)
2. Read-path fails loud, write-path is forgiving — search errors propagate; note-add tolerates embed failure and heals later via `repair`
3. Per-document embedding metadata — every vector row carries `(doc_id, backend, model, dim)`, enabling mixed-backend cross-machine coexistence
4. Markdown is source of truth — sync ships markdown only, each machine rebuilds its own SQLite index + embeds under its own backend
5. TF-IDF is a first-class explicit choice, not a safety net

## Phases

| Phase | Commit | Deliverable |
|---|---|---|
| P1 | `bb4dded` | Embedder interface + schema v22 with preservation migration (protects MacBook's real Ollama vectors) |
| P2 | `3e2265d` | Gemini provider (new cloud #1 — verified MTEB multilingual lead, $0.15/M) |
| P3 | `60493f5` | `claudemem setup` interactive wizard + `IsSecretKey` config guard |
| P4 | `f80a8ee` | Fail-loud on backend failure + TTY interactive recovery (retry / fts-only / setup) |
| P5 | `85d4997` | `claudemem health` + `claudemem repair` with I1–I5 invariants |
| P6 | `a33c118` | `claudemem sync init/push/pull/status` — markdown-only git sync |
| P7 | `74a8226` | Voyage-3.5-lite + OpenAI providers |
| P8 | `226607a` | README updates |
| Review | `b15dda9`, `da081e6` | Codex + Claude multi-engine review fixes |

## New commands

```
claudemem setup                              # interactive backend wizard (Local/Gemini/Voyage/OpenAI/TF-IDF)
claudemem health [--deep]                    # I1-I5 parity check (SessionStart-safe, <100ms)
claudemem repair [--yes]                     # fix drift interactively
claudemem sync init <remote-url>             # initialize git repo at ~/.claudemem
claudemem sync {push,pull,status}            # cross-machine markdown sync
claudemem search --fts-only                  # per-query opt-out of semantic
```

## Breaking change: schema v22 migration

The `vectors` table schema changes from flat `(id, vector)` to composite `(doc_id, backend, model, dim, vector, created_at)`. **Migration is automatic and preserving** — existing rows are tagged with whatever backend produced them (read from `vector_meta.index_backend`) and copied into the new schema byte-identically. No re-embedding required for upgrade.

Downgrade path: old binaries reading a v22 table will fail with a schema mismatch — this is intentional (acceptable migration design per the plan).

## Review process

Ran `/codex-review` multi-engine review: 1 Codex (GPT-5.4) + 3 Claude agents. Findings, all addressed before merge:

**CRITICAL**:
- Codex P1: `HybridSearch` silently swallowed `ErrBackendUnavailable`, defeating the entire P4 fail-loud design → fixed in `b15dda9` + regression test
- Agent 1: Voyage/OpenAI `embedBatchOne` panic on partial response → added length guard matching Gemini

**HIGH**:
- `cmd/repair.go` DELETE errors swallowed → surface as wrapped errors
- `gitsync.Init` didn't create dir → `os.MkdirAll` on first run
- `cmd/health.go` ignored `features.semantic_search` flag → gated like search/reindex
- OpenAI `Available()` nil-request panic risk → handle `http.NewRequest` error
- `saveIndexBackend` swallowed errors → logged

**MEDIUM** (polish, `da081e6`):
- `readMeta` now distinguishes DB errors from ErrNoRows (protects migration)
- Voyage `Available()` no longer burns billed tokens as health probe
- `gitsync.git()` captures `CombinedOutput` so hook contexts see actual git errors
- Dead code removed (`gitMaybe`, `healthQuick` var)
- Plan doc reconcile section aligned with code reality

## Test plan

All tests pass locally (`go test ./...`):
- [x] `pkg/vectors` — 20+ tests (interface contract, migration preservation, mixed-backend coexistence, Gemini/Voyage/OpenAI HTTP round-trips, fail-loud read-path, forgiving write-path, Ollama Available success/failure, health I1-I5)
- [x] `pkg/storage` — existing dedup/FTS tests unchanged (no regressions)
- [x] `pkg/sync` — round-trip push/pull via local bare repo, gitignore exclusions
- [x] `pkg/config` — wizard flows, IsSecretKey, ApplyBackendToConfig (verifies raw key never on disk)

Manual smoke tests to run post-merge:
- [ ] `claudemem setup` with `embedding.backend=gemini` + real GEMINI_API_KEY → reindex → `claudemem search "多路复用器"` returns Zellij notes
- [ ] Kill Ollama daemon mid-session → `claudemem search` exits 1 with recovery message (non-TTY) or interactive prompt (TTY)
- [ ] `claudemem sync init <remote>` on MacBook + web_dev → cross-machine round-trip with mixed backends (Gemini web_dev, Ollama MacBook)
- [ ] `claudemem health` on a fresh install with `features.semantic_search=false` → no spurious I3/I5 drift warnings

## Related docs

- `docs/HYBRID_EMBEDDING_PLAN.md` — full architectural plan (v2, supersedes v1)
- `docs/HOOK_INTEGRATION.md` — Claude Code hook additions for auto-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)