### PR TITLE
Fix sync status JSON and hook-safe health

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ build:
 # Install to ~/.local/bin/
 install: build
 	mkdir -p $(HOME)/.local/bin
-	cp $(BINARY) $(HOME)/.local/bin/$(BINARY)
+	tmp="$(HOME)/.local/bin/$(BINARY).tmp.$$$$" && \
+		cp $(BINARY) "$$tmp" && \
+		chmod 755 "$$tmp" && \
+		mv "$$tmp" $(HOME)/.local/bin/$(BINARY)
 	@echo "Installed to $(HOME)/.local/bin/$(BINARY)"
 
 # Quick smoke test

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/zelinewang/claudemem/pkg/config"
@@ -12,7 +13,10 @@ import (
 
 // healthDeep is the only runtime flag — "--quick" is the default and
 // doesn't need a separate bool since `health` without flags IS quick.
-var healthDeep bool
+var (
+	healthDeep         bool
+	healthTrafficLight bool
+)
 
 var healthCmd = &cobra.Command{
 	Use:   "health",
@@ -48,6 +52,10 @@ func runHealth(cmd *cobra.Command, args []string) error {
 
 	fileStore, err := getFileStore()
 	if err != nil {
+		if healthTrafficLight {
+			printHealthTrafficLight(nil, err)
+			return nil
+		}
 		return err
 	}
 	defer fileStore.Close()
@@ -78,7 +86,16 @@ func runHealth(cmd *cobra.Command, args []string) error {
 		report, err = vectors.CheckHealth(in)
 	}
 	if err != nil {
+		if healthTrafficLight {
+			printHealthTrafficLight(nil, err)
+			return nil
+		}
 		return fmt.Errorf("health check failed: %w", err)
+	}
+
+	if healthTrafficLight {
+		printHealthTrafficLight(report, nil)
+		return nil
 	}
 
 	printHealthReport(report, fileStore)
@@ -124,10 +141,46 @@ func printHealthReport(r *vectors.HealthReport, fs *storage.FileStore) {
 	}
 }
 
+func printHealthTrafficLight(r *vectors.HealthReport, err error) {
+	if err != nil {
+		fmt.Printf("claudemem health: RED check failed (%s)\n", err)
+		return
+	}
+	if r == nil {
+		fmt.Println("claudemem health: RED check failed")
+		return
+	}
+
+	vectorLine := "no active vector backend"
+	if r.ActiveBackend != "" {
+		key := r.ActiveBackend + ":" + r.ActiveModel
+		vectorLine = fmt.Sprintf("%d vectors for %s", r.VectorTotals[key], key)
+	}
+
+	if r.Healthy() {
+		fmt.Printf("claudemem health: GREEN healthy (%d markdown, %d entries, %d FTS, %s)\n",
+			r.MarkdownFiles, r.EntriesTotal, r.FTSTotal, vectorLine)
+		return
+	}
+
+	codes := make([]string, 0, len(r.Issues))
+	for _, issue := range r.Issues {
+		if len(issue) >= 2 && issue[0] == 'I' {
+			codes = append(codes, issue[:2])
+		}
+	}
+	if len(codes) == 0 {
+		codes = append(codes, "drift")
+	}
+	fmt.Printf("claudemem health: YELLOW drift (%s) - run `claudemem repair` or `claudemem reindex --vectors`\n",
+		strings.Join(codes, ","))
+}
+
 func init() {
 	// --quick is the default; we keep it as a no-op flag for docs/explicit
 	// scripts that want to signal intent. --deep adds I4/I5 invariants.
 	healthCmd.Flags().Bool("quick", false, "Quick mode (default; <100ms SessionStart-safe)")
 	healthCmd.Flags().BoolVar(&healthDeep, "deep", false, "Deep mode: also check for orphans + config match (I4/I5)")
+	healthCmd.Flags().BoolVar(&healthTrafficLight, "traffic-light", false, "Hook-safe one-line GREEN/YELLOW/RED health status; always exits 0")
 	rootCmd.AddCommand(healthCmd)
 }

--- a/cmd/health.go
+++ b/cmd/health.go
@@ -29,6 +29,7 @@ Invariants (quick mode, <100ms, runs on SessionStart):
   I1  Every markdown file has a row in entries
   I2  Every entry has a row in memory_fts
   I3  Every entry has a vector row for the CURRENTLY CONFIGURED (backend, model)
+  I6  Cloud embedding backends have their configured API key env var present
 
 Deep mode (--deep, slower) additionally validates:
   I4  No orphan FTS / vector rows (parent entry deleted)
@@ -92,6 +93,7 @@ func runHealth(cmd *cobra.Command, args []string) error {
 		}
 		return fmt.Errorf("health check failed: %w", err)
 	}
+	applyEmbeddingConfigHealth(report, cfg)
 
 	if healthTrafficLight {
 		printHealthTrafficLight(report, nil)
@@ -124,7 +126,7 @@ func printHealthReport(r *vectors.HealthReport, fs *storage.FileStore) {
 		return
 	}
 
-	fmt.Fprintln(os.Stderr, "⚠ drift detected")
+	fmt.Fprintln(os.Stderr, "⚠ health issues detected")
 	for _, issue := range r.Issues {
 		fmt.Fprintf(os.Stderr, "   %s\n", issue)
 	}
@@ -163,17 +165,76 @@ func printHealthTrafficLight(r *vectors.HealthReport, err error) {
 		return
 	}
 
-	codes := make([]string, 0, len(r.Issues))
-	for _, issue := range r.Issues {
+	codes := healthIssueCodes(r.Issues)
+	if len(codes) == 0 {
+		codes = append(codes, "drift")
+	}
+	if containsString(codes, "I6") {
+		fmt.Printf("claudemem health: RED backend unavailable (%s) - export API key or run `claudemem setup`\n",
+			strings.Join(codes, ","))
+		return
+	}
+	fmt.Printf("claudemem health: YELLOW drift (%s) - run `claudemem repair` or `claudemem reindex --vectors`\n",
+		strings.Join(codes, ","))
+}
+
+func applyEmbeddingConfigHealth(r *vectors.HealthReport, cfg *config.Config) {
+	if r == nil || cfg == nil || !cfg.GetBool("features.semantic_search") {
+		return
+	}
+
+	backend := strings.ToLower(cfg.GetString("embedding.backend"))
+	if backend == "" {
+		backend = "tfidf"
+	}
+	defaultKeyEnv := defaultEmbeddingAPIKeyEnv(backend)
+	if defaultKeyEnv == "" {
+		return
+	}
+	keyEnv := cfg.GetString("embedding.api_key_env")
+	if keyEnv == "" {
+		keyEnv = defaultKeyEnv
+	}
+	if os.Getenv(keyEnv) != "" {
+		return
+	}
+
+	r.I6ActiveBackendConfigured = false
+	r.Issues = append(r.Issues, fmt.Sprintf(
+		"I6: active backend %s expects env var %s, but it is not set. Export it or run `claudemem setup`.",
+		backend, keyEnv))
+}
+
+func defaultEmbeddingAPIKeyEnv(backend string) string {
+	switch backend {
+	case "gemini":
+		return "GEMINI_API_KEY"
+	case "voyage":
+		return "VOYAGE_API_KEY"
+	case "openai":
+		return "OPENAI_API_KEY"
+	default:
+		return ""
+	}
+}
+
+func healthIssueCodes(issues []string) []string {
+	codes := make([]string, 0, len(issues))
+	for _, issue := range issues {
 		if len(issue) >= 2 && issue[0] == 'I' {
 			codes = append(codes, issue[:2])
 		}
 	}
-	if len(codes) == 0 {
-		codes = append(codes, "drift")
+	return codes
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
 	}
-	fmt.Printf("claudemem health: YELLOW drift (%s) - run `claudemem repair` or `claudemem reindex --vectors`\n",
-		strings.Join(codes, ","))
+	return false
 }
 
 func init() {

--- a/cmd/health_test.go
+++ b/cmd/health_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/zelinewang/claudemem/pkg/config"
+	"github.com/zelinewang/claudemem/pkg/vectors"
+)
+
+func TestApplyEmbeddingConfigHealthMissingCloudKey(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+	cfg := testHealthConfig(t, "gemini", "GEMINI_API_KEY")
+	report := healthyHealthReport()
+
+	applyEmbeddingConfigHealth(report, cfg)
+
+	if report.I6ActiveBackendConfigured {
+		t.Fatal("expected missing Gemini key to fail I6")
+	}
+	if report.Healthy() {
+		t.Fatal("report with missing Gemini key should not be healthy")
+	}
+	if len(report.Issues) == 0 || report.Issues[0][:2] != "I6" {
+		t.Fatalf("expected I6 issue, got %#v", report.Issues)
+	}
+}
+
+func TestApplyEmbeddingConfigHealthPresentCloudKey(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "test-key")
+	cfg := testHealthConfig(t, "gemini", "GEMINI_API_KEY")
+	report := healthyHealthReport()
+
+	applyEmbeddingConfigHealth(report, cfg)
+
+	if !report.I6ActiveBackendConfigured {
+		t.Fatal("expected configured Gemini key to pass I6")
+	}
+	if !report.Healthy() {
+		t.Fatalf("report should remain healthy, got %#v", report.Issues)
+	}
+}
+
+func TestApplyEmbeddingConfigHealthIgnoresLocalBackend(t *testing.T) {
+	t.Setenv("GEMINI_API_KEY", "")
+	cfg := testHealthConfig(t, "tfidf", "GEMINI_API_KEY")
+	report := healthyHealthReport()
+
+	applyEmbeddingConfigHealth(report, cfg)
+
+	if !report.Healthy() {
+		t.Fatalf("local backend should not require cloud key, got %#v", report.Issues)
+	}
+}
+
+func testHealthConfig(t *testing.T, backend, keyEnv string) *config.Config {
+	t.Helper()
+	cfg, err := config.Load(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg.Set("features.semantic_search", true)
+	cfg.Set("embedding.backend", backend)
+	cfg.Set("embedding.api_key_env", keyEnv)
+	return cfg
+}
+
+func healthyHealthReport() *vectors.HealthReport {
+	return &vectors.HealthReport{
+		I1MarkdownMatchesEntries:    true,
+		I2EntriesMatchesFTS:         true,
+		I3VectorsMatchActiveBackend: true,
+		I6ActiveBackendConfigured:   true,
+	}
+}

--- a/cmd/repair.go
+++ b/cmd/repair.go
@@ -58,12 +58,13 @@ func runRepair(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	applyEmbeddingConfigHealth(report, cfg)
 	if report.Healthy() {
 		OutputText("✓ healthy, nothing to repair")
 		return nil
 	}
 
-	fmt.Fprintln(os.Stderr, "⚠ drift detected:")
+	fmt.Fprintln(os.Stderr, "⚠ health issues detected:")
 	for _, issue := range report.Issues {
 		fmt.Fprintf(os.Stderr, "   %s\n", issue)
 	}
@@ -134,6 +135,7 @@ func runRepair(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	applyEmbeddingConfigHealth(report2, cfg)
 	if report2.Healthy() {
 		OutputText("✓ healthy now")
 	} else {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/zelinewang/claudemem/pkg/sync"
@@ -118,12 +119,9 @@ var syncPullCmd = &cobra.Command{
 		vectorsAdded := 0
 		_ = store.InitVectorStore()
 		if store.HasVectorStore() {
-			// Full reindex is simpler than diff-based partial embed for v1;
-			// RebuildIndex already scopes the wipe to the active
-			// (backend, model) so cross-machine rows are preserved.
-			n, err := store.ReindexVectors()
+			n, err := store.IndexMissingVectors()
 			if err != nil {
-				return fmt.Errorf("vector reindex post-pull: %w", err)
+				return fmt.Errorf("vector catch-up post-pull: %w", err)
 			}
 			vectorsAdded = n
 		}
@@ -146,27 +144,86 @@ var syncStatusCmd = &cobra.Command{
 	Short: "Show git status + health of the local memory store",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		g := sync.NewGitSync(getStoreDir())
-		if !g.IsInitialized() {
-			OutputText("not initialized — run `claudemem sync init <remote-url>` to start")
-			return nil
-		}
-		out, err := g.Status()
+		status, err := newSyncStatusPayload(g, getStoreDir())
 		if err != nil {
 			return err
 		}
-		remote := g.RemoteURL()
-		if remote == "" {
-			remote = "(none)"
+
+		if outputFormat == "json" {
+			return OutputJSON(status)
 		}
-		OutputText("Remote:  %s", remote)
-		OutputText("Storage: %s", getStoreDir())
-		if out == "" {
+
+		if !status.Initialized {
+			OutputText("not initialized — run `claudemem sync init <remote-url>` to start")
+			return nil
+		}
+		OutputText("Remote:  %s", status.Remote)
+		OutputText("Storage: %s", status.Storage)
+		if status.Clean {
 			OutputText("Status:  clean (no uncommitted changes)")
 		} else {
-			OutputText("Status:\n%s", out)
+			OutputText("Status:\n%s", status.Status)
 		}
 		return nil
 	},
+}
+
+type syncStatusPayload struct {
+	Initialized bool     `json:"initialized"`
+	Remote      string   `json:"remote"`
+	Storage     string   `json:"storage"`
+	Clean       bool     `json:"clean"`
+	Status      string   `json:"status"`
+	StatusLines []string `json:"status_lines"`
+}
+
+type syncStatusProvider interface {
+	IsInitialized() bool
+	RemoteURL() string
+	Status() (string, error)
+}
+
+func newSyncStatusPayload(g syncStatusProvider, storage string) (syncStatusPayload, error) {
+	status := syncStatusPayload{
+		Initialized: g.IsInitialized(),
+		Storage:     storage,
+	}
+	if !status.Initialized {
+		status.Remote = ""
+		status.Clean = false
+		status.Status = "not initialized"
+		status.StatusLines = []string{}
+		return status, nil
+	}
+
+	remote := g.RemoteURL()
+	if remote == "" {
+		remote = "(none)"
+	}
+	out, err := g.Status()
+	if err != nil {
+		return status, err
+	}
+	status.Remote = remote
+	status.Status = strings.TrimSpace(out)
+	status.StatusLines = splitGitStatusLines(status.Status)
+	status.Clean = len(status.StatusLines) == 0
+	return status, nil
+}
+
+func splitGitStatusLines(status string) []string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return []string{}
+	}
+	lines := strings.Split(status, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }
 
 func init() {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -74,12 +74,7 @@ var syncPushCmd = &cobra.Command{
 		msg, _ := cmd.Flags().GetString("message")
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		if err := g.Push(msg); err != nil {
-			if !quiet {
-				return err
-			}
-			// Quiet mode for hook invocations: log to stderr, exit 0
-			fmt.Fprintf(os.Stderr, "claudemem sync push (quiet): %v\n", err)
-			return nil
+			return syncCommandError("push", quiet, err)
 		}
 		if !quiet {
 			OutputText("✓ pushed memory to %s", g.RemoteURL())
@@ -95,11 +90,7 @@ var syncPullCmd = &cobra.Command{
 		quiet, _ := cmd.Flags().GetBool("quiet")
 		g := sync.NewGitSync(getStoreDir())
 		if err := g.Pull(); err != nil {
-			if !quiet {
-				return err
-			}
-			fmt.Fprintf(os.Stderr, "claudemem sync pull (quiet): %v\n", err)
-			return nil
+			return syncCommandError("pull", quiet, err)
 		}
 
 		// Reconcile: rebuild FTS from markdown (cheap), then embed any docs
@@ -137,6 +128,16 @@ var syncPullCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+func syncCommandError(action string, quiet bool, err error) error {
+	if err == nil {
+		return nil
+	}
+	if quiet {
+		return fmt.Errorf("claudemem sync %s (quiet): %w", action, err)
+	}
+	return err
 }
 
 var syncStatusCmd = &cobra.Command{

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/zelinewang/claudemem/pkg/config"
 	"github.com/zelinewang/claudemem/pkg/sync"
 )
 
@@ -108,7 +109,10 @@ var syncPullCmd = &cobra.Command{
 
 		// Only touch vectors if semantic search is enabled
 		vectorsAdded := 0
-		_ = store.InitVectorStore()
+		cfg, _ := config.Load(getStoreDir())
+		if cfg != nil && cfg.GetBool("features.semantic_search") {
+			_ = store.InitVectorStore()
+		}
 		if store.HasVectorStore() {
 			n, err := store.IndexMissingVectors()
 			if err != nil {

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type fakeSyncStatusProvider struct {
+	initialized bool
+	remote      string
+	status      string
+	err         error
+}
+
+func (f fakeSyncStatusProvider) IsInitialized() bool { return f.initialized }
+func (f fakeSyncStatusProvider) RemoteURL() string   { return f.remote }
+func (f fakeSyncStatusProvider) Status() (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.status, nil
+}
+
+func TestNewSyncStatusPayload_Uninitialized(t *testing.T) {
+	got, err := newSyncStatusPayload(fakeSyncStatusProvider{}, "/tmp/store")
+	if err != nil {
+		t.Fatalf("newSyncStatusPayload: %v", err)
+	}
+	if got.Initialized {
+		t.Fatal("expected initialized=false")
+	}
+	if got.Status != "not initialized" {
+		t.Fatalf("status = %q, want not initialized", got.Status)
+	}
+	if got.Clean {
+		t.Fatal("uninitialized store should not report clean")
+	}
+	if len(got.StatusLines) != 0 {
+		t.Fatalf("status lines = %#v, want empty", got.StatusLines)
+	}
+}
+
+func TestNewSyncStatusPayload_CleanRepo(t *testing.T) {
+	got, err := newSyncStatusPayload(fakeSyncStatusProvider{
+		initialized: true,
+		remote:      "git@example.com:memory.git",
+		status:      "",
+	}, "/tmp/store")
+	if err != nil {
+		t.Fatalf("newSyncStatusPayload: %v", err)
+	}
+	if !got.Clean {
+		t.Fatal("expected clean=true")
+	}
+	if got.Remote != "git@example.com:memory.git" {
+		t.Fatalf("remote = %q", got.Remote)
+	}
+	if len(got.StatusLines) != 0 {
+		t.Fatalf("status lines = %#v, want empty", got.StatusLines)
+	}
+}
+
+func TestNewSyncStatusPayload_DirtyRepo(t *testing.T) {
+	got, err := newSyncStatusPayload(fakeSyncStatusProvider{
+		initialized: true,
+		status:      "?? notes/project/new.md\n M notes/reference/existing.md\n",
+	}, "/tmp/store")
+	if err != nil {
+		t.Fatalf("newSyncStatusPayload: %v", err)
+	}
+	if got.Clean {
+		t.Fatal("expected clean=false")
+	}
+	if got.Remote != "(none)" {
+		t.Fatalf("remote = %q, want (none)", got.Remote)
+	}
+	want := []string{"?? notes/project/new.md", "M notes/reference/existing.md"}
+	if !reflect.DeepEqual(got.StatusLines, want) {
+		t.Fatalf("status lines = %#v, want %#v", got.StatusLines, want)
+	}
+}
+
+func TestNewSyncStatusPayload_StatusError(t *testing.T) {
+	_, err := newSyncStatusPayload(fakeSyncStatusProvider{
+		initialized: true,
+		err:         errors.New("git failed"),
+	}, "/tmp/store")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -90,3 +90,22 @@ func TestNewSyncStatusPayload_StatusError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+func TestSyncCommandErrorQuietStillFails(t *testing.T) {
+	baseErr := errors.New("git failed")
+	err := syncCommandError("pull", true, baseErr)
+	if err == nil {
+		t.Fatal("quiet sync error should still fail")
+	}
+	if !errors.Is(err, baseErr) {
+		t.Fatalf("quiet sync error should wrap original error, got %v", err)
+	}
+}
+
+func TestSyncCommandErrorNonQuietReturnsOriginal(t *testing.T) {
+	baseErr := errors.New("git failed")
+	err := syncCommandError("push", false, baseErr)
+	if !errors.Is(err, baseErr) {
+		t.Fatalf("non-quiet sync error should return original error, got %v", err)
+	}
+}

--- a/pkg/storage/filestore.go
+++ b/pkg/storage/filestore.go
@@ -44,7 +44,13 @@ func NewFileStore(baseDir string) (*FileStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+	db.SetMaxOpenConns(1)
 	fs.db = db
+
+	if err := fs.configureSQLite(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to configure database: %w", err)
+	}
 
 	// Initialize schema
 	if err := fs.initSchema(); err != nil {
@@ -53,6 +59,21 @@ func NewFileStore(baseDir string) (*FileStore, error) {
 	}
 
 	return fs, nil
+}
+
+// configureSQLite keeps CLI invocations friendly under hook/search concurrency.
+func (fs *FileStore) configureSQLite() error {
+	pragmas := []string{
+		"PRAGMA busy_timeout=5000",
+		"PRAGMA journal_mode=WAL",
+		"PRAGMA synchronous=NORMAL",
+	}
+	for _, pragma := range pragmas {
+		if _, err := fs.db.Exec(pragma); err != nil {
+			return fmt.Errorf("%s: %w", pragma, err)
+		}
+	}
+	return nil
 }
 
 // initSchema creates the database tables

--- a/pkg/storage/filestore_access.go
+++ b/pkg/storage/filestore_access.go
@@ -28,7 +28,7 @@ func (fs *FileStore) LogAccess(entryID, accessType string) {
 		`INSERT INTO access_log (entry_id, accessed_at, access_type) VALUES (?, ?, ?)`,
 		entryID, now, accessType,
 	)
-	if err != nil {
+	if err != nil && os.Getenv("CLAUDEMEM_DEBUG_ACCESS_LOG") == "1" {
 		fmt.Fprintf(os.Stderr, "Warning: failed to log access for %s: %v\n", entryID, err)
 	}
 }

--- a/pkg/storage/filestore_search.go
+++ b/pkg/storage/filestore_search.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"time"
+	"unicode"
 )
 
 // sanitizeFTSQuery makes user input safe for FTS5 MATCH by quoting tokens
@@ -67,7 +68,13 @@ func quoteFTSToken(tok string) string {
 }
 
 func needsQuoting(s string) bool {
-	return strings.ContainsAny(s, `-:^"()`)
+	for _, r := range s {
+		if r == '_' || unicode.IsLetter(r) || unicode.IsNumber(r) {
+			continue
+		}
+		return true
+	}
+	return false
 }
 
 // Search implements full-text search across notes and sessions

--- a/pkg/storage/filestore_search.go
+++ b/pkg/storage/filestore_search.go
@@ -360,7 +360,7 @@ func parseCreatedTimestamp(s string) (time.Time, error) {
 	}
 	var unix int64
 	if _, err := fmt.Sscanf(s, "%d", &unix); err == nil && fmt.Sprintf("%d", unix) == s {
-		return time.Unix(unix, 0), nil
+		return time.Unix(unix, 0).UTC(), nil
 	}
 	return time.Time{}, fmt.Errorf("unable to parse timestamp: %s", s)
 }

--- a/pkg/storage/filestore_test.go
+++ b/pkg/storage/filestore_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/zelinewang/claudemem/pkg/models"
+	"github.com/zelinewang/claudemem/pkg/vectors"
 )
 
 // setupTestStore creates a temporary FileStore for testing
@@ -19,6 +20,93 @@ func setupTestStore(t *testing.T) *FileStore {
 	}
 	t.Cleanup(func() { store.Close() })
 	return store
+}
+
+type storageCountingEmbedder struct {
+	name, model string
+	dim         int
+	embedded    int
+}
+
+func (e *storageCountingEmbedder) Available() error { return nil }
+func (e *storageCountingEmbedder) Name() string     { return e.name }
+func (e *storageCountingEmbedder) Model() string    { return e.model }
+func (e *storageCountingEmbedder) Dimensions() int  { return e.dim }
+func (e *storageCountingEmbedder) Embed(text string, _ vectors.InputType) ([]float32, error) {
+	e.embedded++
+	return countedVector(text, e.dim), nil
+}
+func (e *storageCountingEmbedder) EmbedBatch(texts []string, _ vectors.InputType) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, text := range texts {
+		e.embedded++
+		out[i] = countedVector(text, e.dim)
+	}
+	return out, nil
+}
+
+func countedVector(text string, dim int) []float32 {
+	vec := make([]float32, dim)
+	for i := 0; i < dim; i++ {
+		vec[i] = float32((len(text)+i)%97) / 97.0
+	}
+	return vec
+}
+
+func writeNoteMarkdown(t *testing.T, store *FileStore, filename, category, title, content string) {
+	t.Helper()
+	note := models.NewNote(category, title, content)
+	path := filepath.Join(store.notesDir, filename)
+	if err := os.WriteFile(path, []byte(FormatNoteMarkdown(note)), 0600); err != nil {
+		t.Fatalf("write note markdown: %v", err)
+	}
+}
+
+func TestFileStore_IndexMissingVectorsSkipsExistingDocs(t *testing.T) {
+	store := setupTestStore(t)
+	embedder := &storageCountingEmbedder{name: "fake-cloud", model: "test-v1", dim: 4}
+	vs, err := vectors.NewVectorStore(store.db, embedder)
+	if err != nil {
+		t.Fatalf("NewVectorStore failed: %v", err)
+	}
+	store.vectorStore = vs
+
+	writeNoteMarkdown(t, store, "one.md", "sync", "First", "first remote note")
+	writeNoteMarkdown(t, store, "two.md", "sync", "Second", "second remote note")
+
+	indexed, err := store.IndexMissingVectors()
+	if err != nil {
+		t.Fatalf("IndexMissingVectors failed: %v", err)
+	}
+	if indexed != 2 {
+		t.Fatalf("first IndexMissingVectors indexed %d docs, want 2", indexed)
+	}
+	if embedder.embedded != 2 {
+		t.Fatalf("embed calls after first pass = %d, want 2", embedder.embedded)
+	}
+
+	indexed, err = store.IndexMissingVectors()
+	if err != nil {
+		t.Fatalf("second IndexMissingVectors failed: %v", err)
+	}
+	if indexed != 0 {
+		t.Fatalf("second IndexMissingVectors indexed %d docs, want 0", indexed)
+	}
+	if embedder.embedded != 2 {
+		t.Fatalf("embed calls after no-op pass = %d, want 2", embedder.embedded)
+	}
+
+	writeNoteMarkdown(t, store, "three.md", "sync", "Third", "third remote note")
+	indexed, err = store.IndexMissingVectors()
+	if err != nil {
+		t.Fatalf("third IndexMissingVectors failed: %v", err)
+	}
+	if indexed != 1 {
+		t.Fatalf("third IndexMissingVectors indexed %d docs, want 1", indexed)
+	}
+	if embedder.embedded != 3 {
+		t.Fatalf("embed calls after missing pass = %d, want 3", embedder.embedded)
+	}
 }
 
 func TestFileStore_NoteWithSessionID(t *testing.T) {
@@ -486,4 +574,3 @@ func TestFileStore_DeleteNote(t *testing.T) {
 		t.Errorf("Note should not exist after deletion")
 	}
 }
-

--- a/pkg/storage/filestore_vectors.go
+++ b/pkg/storage/filestore_vectors.go
@@ -357,13 +357,7 @@ func (fs *FileStore) matchesFacets(id string, opts SearchOpts) bool {
 	return err == nil
 }
 
-// ReindexVectors rebuilds the entire vector index from all notes and sessions on disk.
-// Returns the number of documents indexed.
-func (fs *FileStore) ReindexVectors() (int, error) {
-	if fs.vectorStore == nil {
-		return 0, fmt.Errorf("semantic search not enabled; run: claudemem config set features.semantic_search true")
-	}
-
+func (fs *FileStore) collectVectorDocuments() []vectors.Document {
 	var docs []vectors.Document
 
 	// Collect notes
@@ -414,7 +408,50 @@ func (fs *FileStore) ReindexVectors() (int, error) {
 		})
 	}
 
-	// Rebuild the index
+	return docs
+}
+
+// IndexMissingVectors embeds only documents that do not yet have a vector row
+// for the active backend. TF-IDF still needs a full corpus rebuild because its
+// vocabulary is corpus-wide.
+func (fs *FileStore) IndexMissingVectors() (int, error) {
+	if fs.vectorStore == nil {
+		return 0, fmt.Errorf("semantic search not enabled; run: claudemem config set features.semantic_search true")
+	}
+
+	docs := fs.collectVectorDocuments()
+	if strings.HasPrefix(fs.VectorBackend(), "tfidf:") {
+		if err := fs.vectorStore.RebuildIndex(docs); err != nil {
+			return 0, fmt.Errorf("failed to rebuild vector index: %w", err)
+		}
+		return len(docs), nil
+	}
+
+	ids := make([]string, 0, len(docs))
+	for _, doc := range docs {
+		ids = append(ids, doc.ID)
+	}
+	missing, err := fs.vectorStore.MissingDocumentIDs(ids)
+	if err != nil {
+		return 0, err
+	}
+	missingDocs := make([]vectors.Document, 0, len(missing))
+	for _, doc := range docs {
+		if missing[doc.ID] {
+			missingDocs = append(missingDocs, doc)
+		}
+	}
+	return fs.vectorStore.UpsertDocuments(missingDocs)
+}
+
+// ReindexVectors rebuilds the entire vector index from all notes and sessions on disk.
+// Returns the number of documents indexed.
+func (fs *FileStore) ReindexVectors() (int, error) {
+	if fs.vectorStore == nil {
+		return 0, fmt.Errorf("semantic search not enabled; run: claudemem config set features.semantic_search true")
+	}
+
+	docs := fs.collectVectorDocuments()
 	if err := fs.vectorStore.RebuildIndex(docs); err != nil {
 		return 0, fmt.Errorf("failed to rebuild vector index: %w", err)
 	}

--- a/pkg/storage/migrate.go
+++ b/pkg/storage/migrate.go
@@ -279,15 +279,24 @@ type OrphanEntry struct {
 // Reindex rebuilds the SQLite index from markdown files on disk.
 // Used after import to populate the search index.
 func (fs *FileStore) Reindex() (int, error) {
-	// Clear existing index
-	fs.db.Exec("DELETE FROM entries")
-	fs.db.Exec("DELETE FROM memory_fts")
+	tx, err := fs.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec("DELETE FROM entries"); err != nil {
+		return 0, fmt.Errorf("clear entries: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM memory_fts"); err != nil {
+		return 0, fmt.Errorf("clear FTS: %w", err)
+	}
 
 	count := 0
 
 	// Reindex notes
 	if _, err := os.Stat(fs.notesDir); err == nil {
-		filepath.Walk(fs.notesDir, func(path string, info os.FileInfo, err error) error {
+		if err := filepath.Walk(fs.notesDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil || info.IsDir() || !strings.HasSuffix(info.Name(), ".md") || strings.HasPrefix(info.Name(), "._") {
 				return nil
 			}
@@ -305,20 +314,26 @@ func (fs *FileStore) Reindex() (int, error) {
 			if note.Metadata != nil {
 				sessionID = note.Metadata["session_id"]
 			}
-			fs.db.Exec(`INSERT OR IGNORE INTO entries (id, type, title, category, session_id, tags, filepath, created, updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			if _, err := tx.Exec(`INSERT INTO entries (id, type, title, category, session_id, tags, filepath, created, updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				note.ID, "note", note.Title, note.Category, sessionID,
 				strings.Join(note.Tags, " "), rel,
-				note.Created.Unix(), note.Updated.Unix())
-			fs.db.Exec(`INSERT OR IGNORE INTO memory_fts (id, title, content, tags) VALUES (?, ?, ?, ?)`,
-				note.ID, note.Title, note.Content, strings.Join(note.Tags, " "))
+				note.Created.Unix(), note.Updated.Unix()); err != nil {
+				return fmt.Errorf("index note entry %s: %w", note.ID, err)
+			}
+			if _, err := tx.Exec(`INSERT INTO memory_fts (id, title, content, tags) VALUES (?, ?, ?, ?)`,
+				note.ID, note.Title, note.Content, strings.Join(note.Tags, " ")); err != nil {
+				return fmt.Errorf("index note FTS %s: %w", note.ID, err)
+			}
 			count++
 			return nil
-		})
+		}); err != nil {
+			return 0, err
+		}
 	}
 
 	// Reindex sessions
 	if _, err := os.Stat(fs.sessionsDir); err == nil {
-		filepath.Walk(fs.sessionsDir, func(path string, info os.FileInfo, err error) error {
+		if err := filepath.Walk(fs.sessionsDir, func(path string, info os.FileInfo, err error) error {
 			if err != nil || info.IsDir() || !strings.HasSuffix(info.Name(), ".md") || strings.HasPrefix(info.Name(), "._") {
 				return nil
 			}
@@ -332,19 +347,28 @@ func (fs *FileStore) Reindex() (int, error) {
 			}
 
 			rel, _ := filepath.Rel(fs.baseDir, path)
-			fs.db.Exec(`INSERT OR IGNORE INTO entries (id, type, title, branch, project, session_id, date_str, tags, filepath, created, updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			if _, err := tx.Exec(`INSERT INTO entries (id, type, title, branch, project, session_id, date_str, tags, filepath, created, updated) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				session.ID, "session", session.Title, session.Branch, session.Project,
 				session.SessionID, session.Date, strings.Join(session.Tags, " "),
 				rel, session.Created.Format("2006-01-02T15:04:05Z"),
-				session.Created.Format("2006-01-02T15:04:05Z"))
-			fs.db.Exec(`INSERT OR IGNORE INTO memory_fts (id, title, content, tags) VALUES (?, ?, ?, ?)`,
+				session.Created.Format("2006-01-02T15:04:05Z")); err != nil {
+				return fmt.Errorf("index session entry %s: %w", session.ID, err)
+			}
+			if _, err := tx.Exec(`INSERT INTO memory_fts (id, title, content, tags) VALUES (?, ?, ?, ?)`,
 				session.ID, session.Title, session.GetSearchableContent(),
-				strings.Join(session.Tags, " "))
+				strings.Join(session.Tags, " ")); err != nil {
+				return fmt.Errorf("index session FTS %s: %w", session.ID, err)
+			}
 			count++
 			return nil
-		})
+		}); err != nil {
+			return 0, err
+		}
 	}
 
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
 	return count, nil
 }
 

--- a/pkg/storage/search_test.go
+++ b/pkg/storage/search_test.go
@@ -329,6 +329,9 @@ func TestSanitizeFTSQuery(t *testing.T) {
 		{"dev-orch*", `"dev-orch"*`},
 		{"prefix:value", `"prefix:value"`},
 		{"^initial", `"^initial"`},
+		{"v3.0.10", `"v3.0.10"`},
+		{"PR#3", `"PR#3"`},
+		{"path/to/file", `"path/to/file"`},
 		{"mixed-hyphen normal", `"mixed-hyphen" normal`},
 		{"", ""},
 		{"  spaces  ", "spaces"},
@@ -421,6 +424,11 @@ func TestSearch_EmbeddedQuoteDoesNotCrash(t *testing.T) {
 	_, err = store.Search("(test)", "", 10)
 	if err != nil {
 		t.Fatalf("Search with parens should not error, got: %v", err)
+	}
+
+	_, err = store.Search("v3.0.10", "", 10)
+	if err != nil {
+		t.Fatalf("Search with dotted version should not error, got: %v", err)
 	}
 }
 

--- a/pkg/sync/gitsync.go
+++ b/pkg/sync/gitsync.go
@@ -139,14 +139,16 @@ func copyDir(src, dst string) error {
 // state into unexpected paths.
 //
 // What is gitignored:
-//   .index/              — SQLite DB; per-machine, rebuildable from markdown
-//   config.json          — per-machine embedding backend choice
-//   .sync_auto_pull      — per-machine auto-sync toggle
-//   .sync_auto_push      — per-machine auto-sync toggle
-//   .bak, .tmp, .swp     — editor temp files
+//
+//	.index/              — SQLite DB; per-machine, rebuildable from markdown
+//	config.json          — per-machine embedding backend choice
+//	.sync_auto_pull      — per-machine auto-sync toggle
+//	.sync_auto_push      — per-machine auto-sync toggle
+//	.bak, .tmp, .swp     — editor temp files
 func (g *GitSync) writeGitignore() error {
 	content := `# claudemem memory sync — per-machine files excluded
 .index/
+index.db
 config.json
 .sync_auto_pull
 .sync_auto_push
@@ -154,6 +156,7 @@ config.json
 # defensive: self-referential or stray symlinks inside the memory dir
 # (e.g. legacy .claudemem -> /home/*/.claudemem left by older installs)
 .claudemem
+.git.*-residue-*
 
 # backup archives — per-machine snapshots, never sync
 *.tar

--- a/pkg/sync/gitsync_test.go
+++ b/pkg/sync/gitsync_test.go
@@ -138,6 +138,7 @@ func TestGitSync_GitignoreExcludesStateFiles(t *testing.T) {
 	}
 	for _, mustExclude := range []string{
 		".index/",
+		"index.db",
 		"config.json",
 		".sync_auto_pull",
 		".sync_auto_push",
@@ -148,6 +149,7 @@ func TestGitSync_GitignoreExcludesStateFiles(t *testing.T) {
 		"*.tar",
 		// defensive: legacy self-referential symlinks
 		".claudemem",
+		".git.*-residue-*",
 		// macOS cross-filesystem residue
 		"._*",
 		".Spotlight-V100",

--- a/pkg/vectors/gemini.go
+++ b/pkg/vectors/gemini.go
@@ -122,8 +122,8 @@ func (g *GeminiEmbedder) Available() error {
 // Embed calls the :embedContent endpoint for a single text.
 func (g *GeminiEmbedder) Embed(text string, t InputType) ([]float32, error) {
 	body := geminiEmbedRequest{
-		Content:             geminiContent{Parts: []geminiPart{{Text: text}}},
-		TaskType:            geminiTaskType(t),
+		Content:              geminiContent{Parts: []geminiPart{{Text: text}}},
+		TaskType:             geminiTaskType(t),
 		OutputDimensionality: g.dim, // omitempty — 0 keeps native
 	}
 	raw, err := json.Marshal(body)
@@ -136,6 +136,14 @@ func (g *GeminiEmbedder) Embed(text string, t InputType) ([]float32, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, &ErrBackendUnavailable{
+			Backend: g.Name() + ":" + g.model,
+			Cause:   fmt.Errorf("auth rejected (HTTP %d): %s", resp.StatusCode, string(b)),
+			Hint:    "verify GEMINI_API_KEY is valid; rotate at https://aistudio.google.com/app/apikey",
+		}
+	}
 	if resp.StatusCode != 200 {
 		b, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("gemini embedContent HTTP %d: %s", resp.StatusCode, string(b))
@@ -182,6 +190,15 @@ func (g *GeminiEmbedder) EmbedBatch(texts []string, t InputType) ([][]float32, e
 		resp, err := g.post("/models/"+g.model+":batchEmbedContents", raw)
 		if err != nil {
 			return nil, err
+		}
+		if resp.StatusCode == 401 || resp.StatusCode == 403 {
+			b, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			return nil, &ErrBackendUnavailable{
+				Backend: g.Name() + ":" + g.model,
+				Cause:   fmt.Errorf("auth rejected (HTTP %d): %s", resp.StatusCode, string(b)),
+				Hint:    "verify GEMINI_API_KEY is valid; rotate at https://aistudio.google.com/app/apikey",
+			}
 		}
 		if resp.StatusCode != 200 {
 			b, _ := io.ReadAll(resp.Body)

--- a/pkg/vectors/gemini_test.go
+++ b/pkg/vectors/gemini_test.go
@@ -174,6 +174,30 @@ func TestGemini_Embed_ErrorBody(t *testing.T) {
 	}
 }
 
+func TestGemini_Embed_AuthRejectedIsBackendUnavailable(t *testing.T) {
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		return 403, `{"error":{"message":"invalid key"}}`
+	})
+	defer srv.Close()
+
+	_, err := emb.Embed("hello", InputTypeQuery)
+	if !IsBackendUnavailable(err) {
+		t.Fatalf("expected ErrBackendUnavailable, got %T: %v", err, err)
+	}
+}
+
+func TestGemini_EmbedBatch_AuthRejectedIsBackendUnavailable(t *testing.T) {
+	srv, emb := newGeminiMockServer(t, func(path string, body []byte) (int, string) {
+		return 403, `{"error":{"message":"invalid key"}}`
+	})
+	defer srv.Close()
+
+	_, err := emb.EmbedBatch([]string{"hello"}, InputTypeDocument)
+	if !IsBackendUnavailable(err) {
+		t.Fatalf("expected ErrBackendUnavailable, got %T: %v", err, err)
+	}
+}
+
 func TestGemini_Name_Model_Dimensions(t *testing.T) {
 	emb := NewGeminiEmbedder("gemini-embedding-001", "k", 1024)
 	if emb.Name() != "gemini" {

--- a/pkg/vectors/health.go
+++ b/pkg/vectors/health.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 )
 
-// HealthReport is the result of a parity check. Each invariant (I1–I5) has
+// HealthReport is the result of a parity check. Each invariant (I1-I6) has
 // a boolean pass/fail + a human-readable message. Quick health check
-// populates I1–I3; Deep also fills I4 + I5 (orphans + config match).
+// populates I1-I3; the CLI may add I6 for embedding backend config; Deep
+// also fills I4 + I5 (orphans + config match).
 type HealthReport struct {
 	// Counts
 	MarkdownFiles int            // I1 lhs
@@ -23,11 +24,12 @@ type HealthReport struct {
 	ActiveModel   string
 
 	// Per-invariant status. False = drift detected.
-	I1MarkdownMatchesEntries bool
-	I2EntriesMatchesFTS      bool
+	I1MarkdownMatchesEntries    bool
+	I2EntriesMatchesFTS         bool
 	I3VectorsMatchActiveBackend bool
-	I4NoOrphanRows               bool // deep only
-	I5VectorMetaMatchesActive    bool // deep only
+	I4NoOrphanRows              bool // deep only
+	I5VectorMetaMatchesActive   bool // deep only
+	I6ActiveBackendConfigured   bool // CLI config check only
 
 	// Human-readable drift descriptions (empty when all pass)
 	Issues []string
@@ -40,7 +42,8 @@ type HealthReport struct {
 func (h *HealthReport) Healthy() bool {
 	base := h.I1MarkdownMatchesEntries &&
 		h.I2EntriesMatchesFTS &&
-		h.I3VectorsMatchActiveBackend
+		h.I3VectorsMatchActiveBackend &&
+		h.I6ActiveBackendConfigured
 	if !h.DidDeepCheck {
 		return base
 	}
@@ -59,7 +62,10 @@ type HealthInputs struct {
 // CheckHealth runs the quick parity check (I1–I3). Targets sub-100ms so
 // it can run on every SessionStart hook without blocking the shell.
 func CheckHealth(in HealthInputs) (*HealthReport, error) {
-	r := &HealthReport{VectorTotals: map[string]int{}}
+	r := &HealthReport{
+		VectorTotals:              map[string]int{},
+		I6ActiveBackendConfigured: true,
+	}
 
 	// I1 — markdown files vs entries table
 	mdCount, err := countMarkdownFiles(in.NotesDir, in.SessionsDir)

--- a/pkg/vectors/store.go
+++ b/pkg/vectors/store.go
@@ -351,12 +351,19 @@ type Document struct {
 	Text string
 }
 
+type indexedDocumentVector struct {
+	docID  string
+	vector []float32
+}
+
 // RebuildIndex embeds every document with the ACTIVE backend+model, tagging
 // each row accordingly. Existing rows under OTHER (backend, model) tuples
 // are preserved (cross-machine / switch-back use cases). Only rows under
 // the CURRENT backend+model are wiped and rebuilt.
 //
 // For TF-IDF embedders, this also rebuilds the vocabulary from the corpus.
+// It prepares all embeddings before mutating SQLite so a provider failure
+// cannot leave the active backend with a partial or empty index.
 func (vs *VectorStore) RebuildIndex(documents []Document) error {
 	if err := vs.embedder.Available(); err != nil {
 		return err
@@ -370,6 +377,11 @@ func (vs *VectorStore) RebuildIndex(documents []Document) error {
 		tf.BuildVocab(corpus)
 	}
 
+	indexed, err := vs.embedDocumentsForRebuild(documents)
+	if err != nil {
+		return err
+	}
+
 	tx, err := vs.db.Begin()
 	if err != nil {
 		return err
@@ -381,21 +393,43 @@ func (vs *VectorStore) RebuildIndex(documents []Document) error {
 		return fmt.Errorf("clear active backend rows: %w", err)
 	}
 
-	if len(documents) == 0 {
-		return tx.Commit()
+	backend, model := vs.embedder.Name(), vs.embedder.Model()
+	if len(indexed) > 0 {
+		stmt, err := tx.Prepare(`
+			INSERT INTO vectors (doc_id, backend, model, dim, vector, created_at)
+			VALUES (?, ?, ?, ?, ?, ?)`)
+		if err != nil {
+			return fmt.Errorf("prepare insert: %w", err)
+		}
+		defer stmt.Close()
+
+		now := time.Now().UTC().Format(time.RFC3339)
+		for _, doc := range indexed {
+			if _, err := stmt.Exec(doc.docID, backend, model, len(doc.vector), vectorToBlob(doc.vector), now); err != nil {
+				return fmt.Errorf("insert vector for %s: %w", doc.docID, err)
+			}
+		}
 	}
 
-	stmt, err := tx.Prepare(`
-		INSERT INTO vectors (doc_id, backend, model, dim, vector, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)`)
-	if err != nil {
-		return fmt.Errorf("prepare insert: %w", err)
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit: %w", err)
 	}
-	defer stmt.Close()
+
+	if tf, ok := vs.embedder.(*TFIDFEmbedder); ok {
+		vs.saveTFIDFState(tf)
+	}
+	vs.saveIndexBackend()
+	return nil
+}
+
+func (vs *VectorStore) embedDocumentsForRebuild(documents []Document) ([]indexedDocumentVector, error) {
+	if len(documents) == 0 {
+		return nil, nil
+	}
 
 	const batchSize = 50
-	now := time.Now().UTC().Format(time.RFC3339)
 	backend, model := vs.embedder.Name(), vs.embedder.Model()
+	indexed := make([]indexedDocumentVector, 0, len(documents))
 
 	for i := 0; i < len(documents); i += batchSize {
 		end := i + batchSize
@@ -410,42 +444,24 @@ func (vs *VectorStore) RebuildIndex(documents []Document) error {
 		}
 		embeddings, err := vs.embedder.EmbedBatch(texts, InputTypeDocument)
 		if err != nil {
-			fmt.Fprintf(os.Stderr,
-				"embed batch failed at offset %d (%s:%s): %v — retrying per-doc\n",
-				i, backend, model, err)
-			for _, d := range batch {
-				vec, singleErr := vs.embedder.Embed(TruncateForEmbed(d.Text), InputTypeDocument)
-				if singleErr != nil || vec == nil {
-					fmt.Fprintf(os.Stderr, "  skip %s: %v\n", shortID(d.ID), singleErr)
-					continue
-				}
-				if _, err := stmt.Exec(d.ID, backend, model, len(vec), vectorToBlob(vec), now); err != nil {
-					return fmt.Errorf("insert vector for %s: %w", d.ID, err)
-				}
-			}
-			continue
+			return nil, fmt.Errorf("embed batch at offset %d (%s:%s): %w", i, backend, model, err)
+		}
+		if len(embeddings) != len(batch) {
+			return nil, fmt.Errorf("embed batch at offset %d (%s:%s): got %d vectors for %d documents",
+				i, backend, model, len(embeddings), len(batch))
 		}
 
 		for j, d := range batch {
 			vec := embeddings[j]
 			if vec == nil {
-				continue
+				return nil, fmt.Errorf("embed batch at offset %d (%s:%s): nil vector for %s",
+					i+j, backend, model, shortID(d.ID))
 			}
-			if _, err := stmt.Exec(d.ID, backend, model, len(vec), vectorToBlob(vec), now); err != nil {
-				return fmt.Errorf("insert vector for %s: %w", d.ID, err)
-			}
+			indexed = append(indexed, indexedDocumentVector{docID: d.ID, vector: vec})
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return fmt.Errorf("commit: %w", err)
-	}
-
-	if tf, ok := vs.embedder.(*TFIDFEmbedder); ok {
-		vs.saveTFIDFState(tf)
-	}
-	vs.saveIndexBackend()
-	return nil
+	return indexed, nil
 }
 
 // MissingDocumentIDs reports which IDs do not yet have a vector row for the

--- a/pkg/vectors/store.go
+++ b/pkg/vectors/store.go
@@ -358,6 +358,10 @@ type Document struct {
 //
 // For TF-IDF embedders, this also rebuilds the vocabulary from the corpus.
 func (vs *VectorStore) RebuildIndex(documents []Document) error {
+	if err := vs.embedder.Available(); err != nil {
+		return err
+	}
+
 	if tf, ok := vs.embedder.(*TFIDFEmbedder); ok {
 		corpus := make([]string, len(documents))
 		for i, d := range documents {
@@ -442,6 +446,109 @@ func (vs *VectorStore) RebuildIndex(documents []Document) error {
 	}
 	vs.saveIndexBackend()
 	return nil
+}
+
+// MissingDocumentIDs reports which IDs do not yet have a vector row for the
+// active backend+model. It intentionally ignores rows from other backends so
+// cross-machine sync can preserve each machine's embedding choice.
+func (vs *VectorStore) MissingDocumentIDs(ids []string) (map[string]bool, error) {
+	missing := make(map[string]bool, len(ids))
+	if len(ids) == 0 {
+		return missing, nil
+	}
+	for _, id := range ids {
+		missing[id] = true
+	}
+
+	rows, err := vs.db.Query(`
+		SELECT doc_id FROM vectors WHERE backend = ? AND model = ?`,
+		vs.embedder.Name(), vs.embedder.Model())
+	if err != nil {
+		return nil, fmt.Errorf("query active vector ids: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		delete(missing, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return missing, nil
+}
+
+// UpsertDocuments embeds and stores the given documents under the active
+// backend+model without deleting existing rows. It is used by sync pull to
+// fill gaps cheaply after remote markdown changes.
+func (vs *VectorStore) UpsertDocuments(documents []Document) (int, error) {
+	if len(documents) == 0 {
+		return 0, nil
+	}
+	if err := vs.embedder.Available(); err != nil {
+		return 0, err
+	}
+
+	stmt, err := vs.db.Prepare(`
+		INSERT OR REPLACE INTO vectors (doc_id, backend, model, dim, vector, created_at)
+		VALUES (?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		return 0, fmt.Errorf("prepare insert: %w", err)
+	}
+	defer stmt.Close()
+
+	const batchSize = 50
+	now := time.Now().UTC().Format(time.RFC3339)
+	backend, model := vs.embedder.Name(), vs.embedder.Model()
+	indexed := 0
+
+	for i := 0; i < len(documents); i += batchSize {
+		end := i + batchSize
+		if end > len(documents) {
+			end = len(documents)
+		}
+		batch := documents[i:end]
+
+		texts := make([]string, len(batch))
+		for j, d := range batch {
+			texts[j] = TruncateForEmbed(d.Text)
+		}
+		embeddings, err := vs.embedder.EmbedBatch(texts, InputTypeDocument)
+		if err != nil {
+			fmt.Fprintf(os.Stderr,
+				"embed batch failed at offset %d (%s:%s): %v — retrying per-doc\n",
+				i, backend, model, err)
+			for _, d := range batch {
+				vec, singleErr := vs.embedder.Embed(TruncateForEmbed(d.Text), InputTypeDocument)
+				if singleErr != nil || vec == nil {
+					fmt.Fprintf(os.Stderr, "  skip %s: %v\n", shortID(d.ID), singleErr)
+					continue
+				}
+				if _, err := stmt.Exec(d.ID, backend, model, len(vec), vectorToBlob(vec), now); err != nil {
+					return indexed, fmt.Errorf("insert vector for %s: %w", d.ID, err)
+				}
+				indexed++
+			}
+			continue
+		}
+
+		for j, d := range batch {
+			vec := embeddings[j]
+			if vec == nil {
+				continue
+			}
+			if _, err := stmt.Exec(d.ID, backend, model, len(vec), vectorToBlob(vec), now); err != nil {
+				return indexed, fmt.Errorf("insert vector for %s: %w", d.ID, err)
+			}
+			indexed++
+		}
+	}
+
+	vs.saveIndexBackend()
+	return indexed, nil
 }
 
 // Count returns the number of vector rows under the active (backend, model).

--- a/pkg/vectors/store_test.go
+++ b/pkg/vectors/store_test.go
@@ -65,6 +65,55 @@ func TestVectorStore_RebuildIndex(t *testing.T) {
 	}
 }
 
+func TestVectorStore_RebuildIndexFailsBeforeClearingRows(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	healthy, err := NewVectorStore(db, &fakeEmbedder{name: "gemini", model: "test-v1", dim: 4})
+	if err != nil {
+		t.Fatalf("NewVectorStore healthy failed: %v", err)
+	}
+	if err := healthy.RebuildIndex([]Document{{ID: "existing", Text: "keep me"}}); err != nil {
+		t.Fatalf("initial RebuildIndex failed: %v", err)
+	}
+
+	failing, err := NewVectorStore(db, newFailingEmbedder("gemini", "test-v1", "set API key"))
+	if err != nil {
+		t.Fatalf("NewVectorStore failing failed: %v", err)
+	}
+	if err := failing.RebuildIndex([]Document{{ID: "replacement", Text: "do not write"}}); err == nil {
+		t.Fatal("RebuildIndex with unavailable backend should fail")
+	}
+
+	count, err := healthy.Count()
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("active rows after failed rebuild = %d, want 1", count)
+	}
+}
+
+func TestVectorStore_UpsertDocumentsFailsBeforeWriting(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	failing, err := NewVectorStore(db, newFailingEmbedder("gemini", "test-v1", "set API key"))
+	if err != nil {
+		t.Fatalf("NewVectorStore failed: %v", err)
+	}
+	if n, err := failing.UpsertDocuments([]Document{{ID: "new", Text: "do not write"}}); err == nil || n != 0 {
+		t.Fatalf("UpsertDocuments = (%d, %v), want 0 + error", n, err)
+	}
+	count, err := failing.Count()
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("active rows after failed upsert = %d, want 0", count)
+	}
+}
+
 func TestVectorStore_Search(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/pkg/vectors/store_test.go
+++ b/pkg/vectors/store_test.go
@@ -2,6 +2,7 @@ package vectors
 
 import (
 	"database/sql"
+	"errors"
 	"testing"
 
 	_ "modernc.org/sqlite"
@@ -94,6 +95,37 @@ func TestVectorStore_RebuildIndexFailsBeforeClearingRows(t *testing.T) {
 	}
 }
 
+func TestVectorStore_RebuildIndexFailsBeforeClearingRowsOnBatchError(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+
+	healthy, err := NewVectorStore(db, &fakeEmbedder{name: "gemini", model: "test-v1", dim: 4})
+	if err != nil {
+		t.Fatalf("NewVectorStore healthy failed: %v", err)
+	}
+	if err := healthy.RebuildIndex([]Document{{ID: "existing", Text: "keep me"}}); err != nil {
+		t.Fatalf("initial RebuildIndex failed: %v", err)
+	}
+
+	failing, err := NewVectorStore(db, &batchFailingEmbedder{
+		fakeEmbedder: &fakeEmbedder{name: "gemini", model: "test-v1", dim: 4},
+	})
+	if err != nil {
+		t.Fatalf("NewVectorStore failing failed: %v", err)
+	}
+	if err := failing.RebuildIndex([]Document{{ID: "replacement", Text: "do not write"}}); err == nil {
+		t.Fatal("RebuildIndex with batch failure should fail")
+	}
+
+	count, err := healthy.Count()
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("active rows after failed batch rebuild = %d, want 1", count)
+	}
+}
+
 func TestVectorStore_UpsertDocumentsFailsBeforeWriting(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
@@ -112,6 +144,14 @@ func TestVectorStore_UpsertDocumentsFailsBeforeWriting(t *testing.T) {
 	if count != 0 {
 		t.Fatalf("active rows after failed upsert = %d, want 0", count)
 	}
+}
+
+type batchFailingEmbedder struct {
+	*fakeEmbedder
+}
+
+func (f *batchFailingEmbedder) EmbedBatch(texts []string, _ InputType) ([][]float32, error) {
+	return nil, errors.New("simulated batch failure")
 }
 
 func TestVectorStore_Search(t *testing.T) {


### PR DESCRIPTION
## Summary
- return real JSON for `claudemem sync status --format json`
- add hook-safe `claudemem health --traffic-light` output
- ignore legacy sync residue and make SQLite/index rebuilds safer under hook concurrency
- make `sync pull` embed only missing vectors and protect vector rebuilds from unavailable backends

## Verification
- `go test ./... -count=1`
- `claudemem repair --yes`
- `claudemem reindex --vectors`
- `claudemem health --deep --format json`
- `claudemem sync status --format json`
- session-memory hook smoke test