### PR TITLE
Define universal agent integration

### DIFF
--- a/cmd/capture.go
+++ b/cmd/capture.go
@@ -15,22 +15,26 @@ import (
 
 var captureCmd = &cobra.Command{
 	Use:   "capture",
-	Short: "Auto-capture observations from tool output",
-	Long: `Processes tool output from Claude Code PostToolUse hooks and
-automatically extracts noteworthy observations as notes.
+	Short: "Legacy opt-in auto-capture for bounded tool observations",
+	Long: `Legacy opt-in capture command for bounded tool observations.
 
-Designed to be called from a Claude Code PostToolUse hook.
-Reads JSON from stdin with tool name and output, extracts
-key observations, and saves them as notes.
+This command predates the universal hook-event design. It is intentionally
+feature-flagged and should not be used as the default integration path for
+new agents. Future hook support should normalize native Claude Code, Codex,
+or other agent payloads through claudemem hook event and create
+capture candidates before anything is saved.
+
+Reads JSON from stdin with tool name and output, extracts bounded observations,
+and saves them as notes only when explicitly enabled.
 
 Feature-flagged: requires features.auto_capture = true in config.`,
 	RunE: runCapture,
 }
 
 type hookInput struct {
-	ToolName string `json:"tool_name"`
+	ToolName  string          `json:"tool_name"`
 	ToolInput json.RawMessage `json:"tool_input"`
-	Output   string `json:"output"`
+	Output    string          `json:"output"`
 }
 
 func init() {

--- a/docs/COMPARISON_AND_ROADMAP.md
+++ b/docs/COMPARISON_AND_ROADMAP.md
@@ -1,5 +1,12 @@
 # claudemem vs claude-mem: Deep Comparison & Roadmap
 
+> Historical note: this comparison predates the v3.x work that added compact
+> search, context injection, semantic/vector indexing, health checks, sync JSON,
+> and free PR CI. The architectural direction still stands: borrow lifecycle and
+> progressive-disclosure ideas, but keep claudemem a universal, agent-neutral,
+> single-binary memory tool. For the current integration contract, see
+> [Universal Agent Integration](UNIVERSAL_AGENT_INTEGRATION.md).
+
 ## Executive Summary
 
 Two projects solving the same problem — persistent memory for AI coding assistants — with fundamentally different philosophies.

--- a/docs/HOOK_INTEGRATION.md
+++ b/docs/HOOK_INTEGRATION.md
@@ -1,4 +1,21 @@
-# Claude Code Hook Integration
+# Hook Integration
+
+claudemem hook support must be universal. Claude Code and Codex are the
+first-class adapters today, but the core design should remain agent-neutral.
+See [Universal Agent Integration](UNIVERSAL_AGENT_INTEGRATION.md) for the
+normalized event protocol and capture rules.
+
+The short version:
+
+- Hooks are control-plane only: context injection, health, sync, candidate
+  capture, and wrapup reminders.
+- Hooks must not save every tool output or dump transcripts.
+- Automatic capture must be candidate-based:
+  `detect -> classify -> redact -> dedupe/merge -> save/skip`.
+- High-quality session reports still require `/wrapup` or an equivalent
+  model-active workflow.
+
+## Claude Code Hook Integration
 
 claudemem ships with suggested additions to Claude Code's session hooks
 so memory health is checked at session start and memory sync happens at
@@ -62,3 +79,21 @@ ls -la ~/.claudemem/.sync_auto_*
 The two flag files live OUTSIDE config.json so they can be toggled
 per-machine without affecting the shared config. A CI server can run
 with auto-pull on + auto-push off, for example.
+
+## Codex Hook Integration
+
+Codex should use the same claudemem semantics through its own hook config and
+`AGENTS.md` rules:
+
+- `SessionStart`: run context inject, health traffic light, optional sync pull.
+- `PostToolUse`: future candidate capture only, dry-run by default.
+- `Stop`: remind about missing wrapup; do not auto-save a low-quality session.
+
+Current Codex memory discipline should be expressed directly in `AGENTS.md`:
+
+1. Search memory at task start.
+2. Save durable discoveries silently during work.
+3. Save a claudemem session report before ending substantial sessions.
+
+This keeps Codex and Claude Code behavior aligned without making the core
+claudemem store depend on either agent's hook payload shape.

--- a/docs/UNIVERSAL_AGENT_INTEGRATION.md
+++ b/docs/UNIVERSAL_AGENT_INTEGRATION.md
@@ -1,0 +1,217 @@
+# Universal Agent Integration
+
+claudemem must stay useful outside any single coding agent. Claude Code and
+Codex are the first-class targets today, but the integration boundary should
+work for any agent that can run a CLI command with a JSON payload.
+
+## Positioning
+
+claudemem is not an auto-loaded personality file and it is not a log sink. It is
+a durable, searchable, syncable knowledge base for coding agents.
+
+The universal design has three layers:
+
+1. **Core CLI and store**: notes, sessions, search, vectors, sync, repair,
+   health, and future candidate queues. This layer must not know about one
+   agent's hook schema.
+2. **Normalized event protocol**: a small JSON contract that represents agent
+   lifecycle events such as session start, user prompt, tool use, stop, and
+   session end.
+3. **Agent adapters**: thin scripts or config snippets that translate native
+   hook payloads from Claude Code, Codex, or another agent into the normalized
+   event protocol.
+
+This keeps claudemem portable while still giving each agent a native-feeling
+integration.
+
+## First-Class Agents
+
+| Agent | Current role | Integration priority |
+| --- | --- | --- |
+| Claude Code | Mature hook surface and slash-command workflow | P0 |
+| Codex | Current working environment and config-driven memory doctrine | P0 |
+| Other coding agents | Future adapters if they can invoke a CLI with JSON | P2 |
+
+P0 means every new hook/capture/wrapup capability must be reviewed for both
+Claude Code and Codex before it is considered complete.
+
+## Invariants
+
+- **Agent-neutral core**: no core storage or classification code should depend
+  on Claude Code or Codex-specific field names.
+- **Adapters are thin**: adapter scripts may rename fields, set agent metadata,
+  and normalize timestamps, but should not implement memory policy.
+- **Hooks are control-plane only**: hooks may inject context, report health,
+  sync, create capture candidates, or remind the agent to wrap up. Hooks should
+  not dump transcripts or save every tool output.
+- **Candidate-first capture**: automatic capture must follow
+  `detect -> classify -> redact -> dedupe/merge -> save/skip`.
+- **Session reports remain model-active**: high-quality sessions need `/wrapup`
+  or an equivalent model-active workflow. Shell-only session-end hooks may only
+  remind or create a low-fidelity candidate, not default saved sessions.
+- **Nonblocking by default**: startup and shutdown hooks must degrade silently or
+  print one-line status. They must not block agent work when claudemem is
+  unavailable.
+- **Zero-cost default**: local FTS and TF-IDF-compatible behavior must work
+  without paid APIs. Cloud embeddings remain opt-in.
+
+## Normalized Event Shape
+
+Future hook support should target a stable event command:
+
+```bash
+claudemem hook event --dry-run --payload -
+```
+
+The payload should be agent-neutral:
+
+```json
+{
+  "schema_version": "claudemem.hook_event.v1",
+  "agent": {
+    "name": "codex",
+    "version": "unknown",
+    "surface": "desktop"
+  },
+  "event": {
+    "type": "post_tool_use",
+    "native_type": "PostToolUse",
+    "timestamp": "2026-05-13T22:00:00Z"
+  },
+  "session": {
+    "id": "optional-agent-session-id",
+    "cwd": "/path/to/workspace",
+    "project": "optional-project-name",
+    "branch": "optional-git-branch"
+  },
+  "tool": {
+    "name": "Bash",
+    "input_summary": "optional redacted summary",
+    "output_summary": "optional redacted summary",
+    "exit_code": 0
+  },
+  "text": {
+    "user_prompt": "",
+    "assistant_summary": ""
+  },
+  "limits": {
+    "max_payload_bytes": 32768,
+    "allow_network": false
+  }
+}
+```
+
+Native adapters can pass through an additional `raw` object for debugging, but
+the core classifier should make decisions from normalized fields.
+
+## Expected Output
+
+Dry-run mode should return a decision without mutating memory:
+
+```json
+{
+  "action": "candidate",
+  "should_save": false,
+  "signal": "low",
+  "reason": "transient tool output",
+  "proposed_note": null
+}
+```
+
+For high-signal events:
+
+```json
+{
+  "action": "candidate",
+  "should_save": true,
+  "signal": "high",
+  "reason": "verified release fact",
+  "proposed_note": {
+    "category": "project",
+    "title": "claudemem v3.0.11 release",
+    "actionable_summary": "Future agents should treat v3.0.11 as the first release with hook-safe health and free PR CI checks.",
+    "tags": ["claudemem", "release", "ci"]
+  }
+}
+```
+
+Saving should be a second step:
+
+```bash
+claudemem candidates accept <id>
+```
+
+or, for explicitly allowed classes, an opt-in auto-save mode:
+
+```bash
+claudemem hook event --autosave=explicit-user-memory,verified-release --payload -
+```
+
+## Adapter Responsibilities
+
+### Claude Code Adapter
+
+Claude Code can provide lifecycle hooks such as `SessionStart`,
+`UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, and `SessionEnd`.
+
+Recommended mapping:
+
+| Native event | claudemem behavior |
+| --- | --- |
+| `SessionStart` | context inject, health traffic light, optional sync pull |
+| `UserPromptSubmit` | candidate if the user explicitly asks to remember something |
+| `PostToolUse` | candidate only for high-signal, bounded outputs |
+| `Stop` | remind if wrapup appears missing; do not save a session |
+| `SessionEnd` | optional sync push; no default transcript/session dump |
+
+### Codex Adapter
+
+Codex should receive the same memory semantics as Claude Code, but through its
+own config and hook files.
+
+Recommended mapping:
+
+| Native event | claudemem behavior |
+| --- | --- |
+| `SessionStart` | context inject, health traffic light, optional sync pull |
+| `PreToolUse` | no memory writes; safety checks only |
+| `PostToolUse` | candidate only, dry-run by default |
+| `Stop` | wrapup reminder or missing-report warning |
+
+Codex instructions must also state the agent behavior directly in `AGENTS.md`:
+search at task start, save useful discoveries silently, and wrap up before
+ending substantial sessions. Hook support is a safety net, not a replacement
+for model-active judgment.
+
+## What To Borrow From Other Memory Systems
+
+Borrow:
+
+- lifecycle trigger points
+- automatic health/context/sync checks
+- compact context injection
+- progressive disclosure
+- candidate capture and review queues
+
+Do not borrow:
+
+- saving every tool output
+- transcript dumps
+- opaque storage
+- required background workers
+- agent-specific storage paths in the core design
+
+## Implementation Roadmap
+
+1. Add `claudemem hook event --dry-run --payload -`.
+2. Add a deterministic classifier that produces save/skip decisions without
+   network calls.
+3. Add `candidates list/get/accept/reject/stats`.
+4. Add Claude Code and Codex adapter snippets that call the same hook command.
+5. Add actionable summaries to new notes and sessions.
+6. Only after reviewing candidate quality, enable narrow opt-in autosave for
+   explicit user memory requests and verified release/merge/deploy facts.
+
+The first successful version is not the one that saves the most. It is the one
+that makes high-quality memory capture easier without polluting the long-term
+store.


### PR DESCRIPTION
## Summary
- define claudemem as a universal, agent-neutral memory layer for coding agents
- make Claude Code and Codex first-class P0 adapters without binding the core store to either hook schema
- document normalized hook-event payloads, candidate-first capture, and no-log-sink invariants
- update hook docs with Codex parity and mark legacy `capture` as opt-in rather than the future universal path

## Verification
- `make test-all`
- `go test ./cmd ./pkg/...`
- `~/.claude/scripts/pre-public-sweep.sh /Users/zane/claudemem` still reports only pre-existing public-readiness blockers in unrelated tracked files (`cmd/session_save.go`, `cmd/session_validate.go`, `docs/HYBRID_EMBEDDING_PLAN.md`)