### PR TITLE
Add hook event dry-run classifier

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+	hookpkg "github.com/zelinewang/claudemem/pkg/hooks"
+)
+
+var (
+	hookEventDryRun  bool
+	hookEventPayload string
+	hookEvalFixtures string
+)
+
+var hookCmd = &cobra.Command{
+	Use:   "hook",
+	Short: "Evaluate normalized agent hook events",
+	Long: `Evaluate normalized agent hook events without coupling claudemem to a
+specific coding agent's native hook schema.`,
+}
+
+var hookEventCmd = &cobra.Command{
+	Use:   "event",
+	Short: "Dry-run a normalized hook event",
+	Long: `Dry-run a normalized hook event and return a machine-readable decision.
+
+The first version is intentionally non-mutating. It classifies an event as a
+candidate, redacts sensitive text, and reports whether the event is eligible
+for later saving. It does not write notes, sessions, or candidate queue rows.`,
+	RunE: runHookEvent,
+}
+
+var hookEvalCmd = &cobra.Command{
+	Use:   "eval",
+	Short: "Run hook classifier evaluation fixtures",
+	Long: `Run hook classifier evaluation fixtures and report precision, recall,
+and per-case pass/fail status. This is a development harness for improving the
+deterministic classifier before enabling any autosave path.`,
+	RunE: runHookEval,
+}
+
+func init() {
+	rootCmd.AddCommand(hookCmd)
+
+	hookCmd.AddCommand(hookEventCmd)
+	hookEventCmd.Flags().BoolVar(&hookEventDryRun, "dry-run", true, "evaluate only; do not mutate memory")
+	hookEventCmd.Flags().StringVar(&hookEventPayload, "payload", "-", "normalized hook payload path, or - for stdin")
+
+	hookCmd.AddCommand(hookEvalCmd)
+	hookEvalCmd.Flags().StringVar(&hookEvalFixtures, "fixtures", "pkg/hooks/testdata/eval", "directory of hook eval JSON fixtures")
+}
+
+func runHookEvent(cmd *cobra.Command, args []string) error {
+	if !hookEventDryRun {
+		return fmt.Errorf("hook event currently supports dry-run only")
+	}
+
+	data, err := readHookPayload(hookEventPayload, os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	decision, err := runHookEventPayload(data)
+	if err != nil {
+		return err
+	}
+
+	return OutputJSON(decision)
+}
+
+func runHookEventPayload(data []byte) (hookpkg.Decision, error) {
+	return hookpkg.EvaluateEventJSON(data)
+}
+
+func readHookPayload(path string, stdin io.Reader) ([]byte, error) {
+	if path == "" || path == "-" {
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			return nil, fmt.Errorf("read hook payload from stdin: %w", err)
+		}
+		return data, nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read hook payload %s: %w", path, err)
+	}
+	return data, nil
+}
+
+func runHookEval(cmd *cobra.Command, args []string) error {
+	report, err := hookpkg.RunEvalDir(hookEvalFixtures)
+	if err != nil {
+		return err
+	}
+
+	if outputFormat == "json" {
+		return OutputJSON(report)
+	}
+
+	OutputText("hook eval: %d cases, %d passed, %d failed", report.Total, report.Passed, report.Failed)
+	OutputText("precision: %.2f, recall: %.2f, f1: %.2f", report.Precision, report.Recall, report.F1)
+	for _, result := range report.Cases {
+		if result.Pass {
+			continue
+		}
+		OutputText("failed: %s: %v", result.Name, result.Errors)
+	}
+	if report.Failed > 0 {
+		return fmt.Errorf("hook eval failed %d/%d cases", report.Failed, report.Total)
+	}
+
+	return nil
+}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunHookEventPayloadExplicitMemory(t *testing.T) {
+	payload := `{
+		"schema_version": "claudemem.hook_event.v1",
+		"agent": {"name": "codex", "version": "test", "surface": "cli"},
+		"event": {"type": "user_prompt_submit"},
+		"text": {"user_prompt": "Please remember this: hook capture must stay candidate-first."}
+	}`
+
+	got, err := runHookEventPayload([]byte(payload))
+	if err != nil {
+		t.Fatalf("runHookEventPayload: %v", err)
+	}
+
+	if !got.ShouldSave {
+		t.Fatal("expected explicit memory request to be save-eligible")
+	}
+	if got.ProposedNote == nil || got.ProposedNote.Category != "user-requirement" {
+		t.Fatalf("proposed note=%#v, want user-requirement", got.ProposedNote)
+	}
+}
+
+func TestRunHookEventPayloadRejectsUnknownSchema(t *testing.T) {
+	payload := `{
+		"schema_version": "claudemem.hook_event.v0",
+		"event": {"type": "post_tool_use"}
+	}`
+
+	_, err := runHookEventPayload([]byte(payload))
+	if err == nil {
+		t.Fatal("expected schema validation error")
+	}
+	if !strings.Contains(err.Error(), "unsupported hook schema_version") {
+		t.Fatalf("error=%q, want unsupported hook schema_version", err)
+	}
+}
+
+func TestReadHookPayloadFromStdin(t *testing.T) {
+	got, err := readHookPayload("-", strings.NewReader(`{"ok":true}`))
+	if err != nil {
+		t.Fatalf("readHookPayload: %v", err)
+	}
+	if string(got) != `{"ok":true}` {
+		t.Fatalf("payload=%q", string(got))
+	}
+}

--- a/cmd/session_save.go
+++ b/cmd/session_save.go
@@ -25,7 +25,7 @@ var (
 	sessionProblems     []string
 	sessionInsights     []string
 	sessionQuestions    []string
-	sessionNextSteps   []string
+	sessionNextSteps    []string
 	sessionRelatedNotes []string
 )
 
@@ -41,12 +41,12 @@ The session content can be provided in multiple ways:
 
 Example with full markdown:
   claudemem session save --title "Fix auth bug" --branch "main" \
-    --project "/home/user/myapp" --session-id "abc123" \
+    --project "/path/to/myapp" --session-id "abc123" \
     --content "## Summary\nFixed authentication issue..."
 
 Example with structured input:
   claudemem session save --title "Fix auth bug" --branch "main" \
-    --project "/home/user/myapp" --session-id "abc123" \
+    --project "/path/to/myapp" --session-id "abc123" \
     --summary "Fixed the JWT token refresh logic" \
     --decisions "Use Redis for token storage" \
     --decisions "Add 5-minute grace period"
@@ -54,7 +54,7 @@ Example with structured input:
 Example with stdin:
   echo "## Summary\nFixed auth..." | claudemem session save \
     --title "Fix auth bug" --branch "main" \
-    --project "/home/user/myapp" --session-id "abc123"`,
+    --project "/path/to/myapp" --session-id "abc123"`,
 	RunE: runSessionSave,
 }
 

--- a/cmd/session_validate.go
+++ b/cmd/session_validate.go
@@ -21,7 +21,7 @@ The file can be provided as an argument or piped via stdin.
 
 Examples:
   # Validate a file
-  claudemem session validate /tmp/claudemem-session-report.md
+  claudemem session validate ./claudemem-session-report.md
 
   # Validate from stdin
   cat report.md | claudemem session validate

--- a/docs/HYBRID_EMBEDDING_PLAN.md
+++ b/docs/HYBRID_EMBEDDING_PLAN.md
@@ -3,7 +3,7 @@
 **Status**: APPROVED DESIGN (2026-04-14) — supersedes v1 (see git history at `cfe05bd`)
 **Owner**: Zane
 **Effort**: 1.5–2 days focused work (all phases)
-**Branch**: `feat/embedder-interface` (worktree at `/tmp/claudemem-refactor`)
+**Branch**: `feat/embedder-interface` (worktree at a temporary checkout path)
 
 ## Why this version supersedes v1
 

--- a/docs/UNIVERSAL_AGENT_INTEGRATION.md
+++ b/docs/UNIVERSAL_AGENT_INTEGRATION.md
@@ -204,14 +204,37 @@ Do not borrow:
 ## Implementation Roadmap
 
 1. Add `claudemem hook event --dry-run --payload -`.
-2. Add a deterministic classifier that produces save/skip decisions without
-   network calls.
-3. Add `candidates list/get/accept/reject/stats`.
-4. Add Claude Code and Codex adapter snippets that call the same hook command.
-5. Add actionable summaries to new notes and sessions.
-6. Only after reviewing candidate quality, enable narrow opt-in autosave for
+2. Add a deterministic classifier and eval harness that produces save/skip
+   decisions without network calls.
+3. Add backtests against existing notes and session reports before widening
+   classifier rules.
+4. Add a dry-run dedupe threshold experiment before creating any queue write
+   path.
+5. Add `candidates list/get/accept/reject/stats/expire/digest` with bounded
+   queue depth and review backpressure.
+6. Add Claude Code and Codex adapter snippets that call the same hook command.
+7. Add template-based actionable summaries to new notes and sessions. Optional
+   LLM enrichment should be a later, explicit command.
+8. Only after reviewing candidate quality, enable narrow opt-in autosave for
    explicit user memory requests and verified release/merge/deploy facts.
 
 The first successful version is not the one that saves the most. It is the one
 that makes high-quality memory capture easier without polluting the long-term
 store.
+
+## Quality Gates
+
+- **Classifier evals before autosave**: deterministic rules must be tested on a
+  fixture set with reported precision, recall, and F1. Autosave stays disabled
+  until the high-signal class has a reviewed precision target.
+- **Backtests before broad triggers**: broad phrases such as "root cause" or
+  "config gotcha" must be validated against existing notes/session reports
+  before they can become save-eligible.
+- **Dedupe before queue writes**: vector or text similarity thresholds must be
+  tested in dry-run mode against existing memories before candidates can be
+  persisted automatically.
+- **Bounded queues only**: candidate queues need stats, expiry, digest, and
+  backpressure. An unbounded review queue is another log sink.
+- **Template summaries first**: deterministic capture may write structured,
+  template-based actionable summaries. LLM-written summaries are optional
+  enrichment, not a first-version requirement.

--- a/pkg/hooks/classifier.go
+++ b/pkg/hooks/classifier.go
@@ -1,0 +1,219 @@
+package hooks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	secretAssignmentPattern = regexp.MustCompile(`(?i)((?:api[_-]?key|token|secret|password|authorization)\s*[:=]\s*)["']?[^"'\s,;}]+`)
+	bearerTokenPattern      = regexp.MustCompile(`(?i)bearer\s+[a-z0-9._~+/\-]+=*`)
+	commonAPIKeyPattern     = regexp.MustCompile(`(?i)\b(?:sk|ghp|github_pat)_[a-z0-9_]{16,}\b|\bsk-[a-z0-9_-]{20,}\b`)
+)
+
+func ClassifyEvent(event HookEvent) Decision {
+	combined := redactedCombinedText(event)
+	lowerCombined := strings.ToLower(combined)
+	eventType := strings.ToLower(strings.TrimSpace(event.Event.Type))
+
+	warnings := redactionWarnings(event, combined)
+
+	if isExplicitMemoryRequest(eventType, lowerCombined) {
+		return decisionWithWarnings(Decision{
+			Action:     "candidate",
+			ShouldSave: true,
+			Signal:     "high",
+			Reason:     "explicit user memory request",
+			ProposedNote: &ProposedNote{
+				Category:          "user-requirement",
+				Title:             boundedTitle("Explicit memory request", combined),
+				ActionableSummary: "[user-memory] " + boundedSummary(combined),
+				Tags:              compactTags("hook-candidate", "explicit-memory", event.Agent.Name),
+			},
+		}, warnings)
+	}
+
+	if factKind, ok := verifiedOperationalFact(lowerCombined); ok {
+		return decisionWithWarnings(Decision{
+			Action:     "candidate",
+			ShouldSave: true,
+			Signal:     "high",
+			Reason:     fmt.Sprintf("verified %s fact", factKind),
+			ProposedNote: &ProposedNote{
+				Category:          "project",
+				Title:             boundedTitle(fmt.Sprintf("Verified %s fact", factKind), combined),
+				ActionableSummary: fmt.Sprintf("[%s-fact] %s", factKind, boundedSummary(combined)),
+				Tags:              compactTags("hook-candidate", factKind, event.Agent.Name, event.Session.Project),
+			},
+		}, warnings)
+	}
+
+	if isConcreteRootCause(lowerCombined) {
+		return decisionWithWarnings(Decision{
+			Action:       "candidate",
+			ShouldSave:   false,
+			Signal:       "medium",
+			Reason:       "potential root-cause memory requires review",
+			ProposedNote: nil,
+		}, warnings)
+	}
+
+	if isConfigGotcha(lowerCombined) {
+		return decisionWithWarnings(Decision{
+			Action:       "candidate",
+			ShouldSave:   false,
+			Signal:       "medium",
+			Reason:       "potential config gotcha requires review",
+			ProposedNote: nil,
+		}, warnings)
+	}
+
+	return decisionWithWarnings(NewSkipDecision("transient or low-signal hook event"), warnings)
+}
+
+func isExplicitMemoryRequest(eventType, lowerText string) bool {
+	if eventType != "user_prompt" && eventType != "user_prompt_submit" {
+		return false
+	}
+	if containsAny(lowerText, "do not remember", "don't remember", "不要记", "别记") {
+		return false
+	}
+	return containsAny(lowerText,
+		"remember this",
+		"please remember",
+		"save this",
+		"note this",
+		"add this to memory",
+		"记住",
+		"记一下",
+		"请记住",
+		"以后记得",
+	)
+}
+
+func verifiedOperationalFact(lowerText string) (string, bool) {
+	if containsAny(lowerText, "released successfully", "release published", "published successfully", "gh release create", "tagged successfully") {
+		return "release", true
+	}
+	if containsAny(lowerText, "merged successfully", "pull request merged", "pr merged", "merge commit") {
+		return "merge", true
+	}
+	if containsAny(lowerText, "deployed successfully", "deployment succeeded", "deployment completed") {
+		return "deploy", true
+	}
+	return "", false
+}
+
+func isConcreteRootCause(lowerText string) bool {
+	if containsAny(lowerText, "root cause: tbd", "root cause tbd", "root cause unknown") {
+		return false
+	}
+	if !strings.Contains(lowerText, "root cause") {
+		return false
+	}
+	hasFix := containsAny(lowerText, "fixed by", "fix:", "solution:", "resolved by", "repair:")
+	hasEvidence := containsAny(lowerText, "verified", "evidence", ".go:", ".ts:", ".tsx:", ".py:", ".md:")
+	return hasFix && hasEvidence
+}
+
+func isConfigGotcha(lowerText string) bool {
+	return containsAny(lowerText, "config gotcha", "env gotcha", "configuration gotcha", "settings gotcha") &&
+		containsAny(lowerText, "fix", "use ", "set ", "must ", "requires ")
+}
+
+func redactedCombinedText(event HookEvent) string {
+	parts := []string{
+		event.Text.UserPrompt,
+		event.Text.AssistantSummary,
+		event.Tool.InputSummary,
+		event.Tool.OutputSummary,
+	}
+	return RedactSensitiveText(strings.Join(parts, "\n"))
+}
+
+func redactionWarnings(event HookEvent, redacted string) []string {
+	original := strings.Join([]string{
+		event.Text.UserPrompt,
+		event.Text.AssistantSummary,
+		event.Tool.InputSummary,
+		event.Tool.OutputSummary,
+	}, "\n")
+	if original != redacted {
+		return []string{"redacted_sensitive_text"}
+	}
+	return nil
+}
+
+func RedactSensitiveText(text string) string {
+	text = secretAssignmentPattern.ReplaceAllString(text, "${1}[REDACTED]")
+	text = bearerTokenPattern.ReplaceAllString(text, "Bearer [REDACTED]")
+	text = commonAPIKeyPattern.ReplaceAllString(text, "[REDACTED_API_KEY]")
+	return text
+}
+
+func boundedTitle(fallback, text string) string {
+	line := firstInformativeLine(text)
+	if line == "" {
+		return fallback
+	}
+	return truncateRunes(line, 90)
+}
+
+func boundedSummary(text string) string {
+	line := firstInformativeLine(text)
+	if line == "" {
+		return "review the normalized hook candidate before saving."
+	}
+	return truncateRunes(line, 180)
+}
+
+func firstInformativeLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+func containsAny(text string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(text, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func compactTags(tags ...string) []string {
+	seen := map[string]bool{}
+	out := []string{}
+	for _, tag := range tags {
+		tag = strings.ToLower(strings.TrimSpace(tag))
+		tag = strings.ReplaceAll(tag, " ", "-")
+		if tag == "" || seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		out = append(out, tag)
+	}
+	return out
+}
+
+func decisionWithWarnings(decision Decision, warnings []string) Decision {
+	if len(warnings) > 0 {
+		decision.Warnings = warnings
+	}
+	return decision
+}
+
+func truncateRunes(text string, max int) string {
+	runes := []rune(text)
+	if len(runes) <= max {
+		return text
+	}
+	return strings.TrimSpace(string(runes[:max-3])) + "..."
+}

--- a/pkg/hooks/classifier_test.go
+++ b/pkg/hooks/classifier_test.go
@@ -1,0 +1,146 @@
+package hooks
+
+import "testing"
+
+func TestClassifyExplicitMemoryRequest(t *testing.T) {
+	event := baseTestEvent("user_prompt_submit")
+	event.Text.UserPrompt = "Please remember this: Codex and Claude Code are P0 adapters for claudemem."
+
+	got := ClassifyEvent(event)
+
+	if !got.ShouldSave {
+		t.Fatal("explicit memory request should be save-eligible")
+	}
+	if got.Signal != "high" {
+		t.Fatalf("signal=%q, want high", got.Signal)
+	}
+	if got.ProposedNote == nil || got.ProposedNote.Category != "user-requirement" {
+		t.Fatalf("proposed note=%#v, want user-requirement", got.ProposedNote)
+	}
+}
+
+func TestClassifyTransientToolOutput(t *testing.T) {
+	event := baseTestEvent("post_tool_use")
+	event.Tool.Name = "Bash"
+	event.Tool.OutputSummary = "ok github.com/zelinewang/claudemem/pkg/hooks 0.012s\nPASS"
+
+	got := ClassifyEvent(event)
+
+	if got.ShouldSave {
+		t.Fatal("plain test output should not be save-eligible")
+	}
+	if got.Signal != "low" {
+		t.Fatalf("signal=%q, want low", got.Signal)
+	}
+}
+
+func TestClassifyVerifiedReleaseFact(t *testing.T) {
+	event := baseTestEvent("post_tool_use")
+	event.Tool.Name = "gh"
+	event.Tool.OutputSummary = "Release v3.0.11 published successfully and PR checks passed."
+	event.Session.Project = "claudemem"
+
+	got := ClassifyEvent(event)
+
+	if !got.ShouldSave {
+		t.Fatal("verified release fact should be save-eligible")
+	}
+	if got.ProposedNote == nil || got.ProposedNote.Category != "project" {
+		t.Fatalf("proposed note=%#v, want project category", got.ProposedNote)
+	}
+	if !containsTag(got.ProposedNote.Tags, "release") {
+		t.Fatalf("tags=%#v, want release", got.ProposedNote.Tags)
+	}
+}
+
+func TestClassifyReleaseTestOutputIsNotReleaseFact(t *testing.T) {
+	event := baseTestEvent("post_tool_use")
+	event.Tool.Name = "Bash"
+	event.Tool.OutputSummary = "Release tests for v3.0.11 passed."
+
+	got := ClassifyEvent(event)
+
+	if got.ShouldSave {
+		t.Fatal("release test output should not be treated as a verified release fact")
+	}
+	if got.Signal != "low" {
+		t.Fatalf("signal=%q, want low", got.Signal)
+	}
+}
+
+func TestClassifyDoNotRememberIsNotMemoryRequest(t *testing.T) {
+	event := baseTestEvent("user_prompt_submit")
+	event.Text.UserPrompt = "Do not remember this temporary workaround."
+
+	got := ClassifyEvent(event)
+
+	if got.ShouldSave {
+		t.Fatal("negative memory request should not be save-eligible")
+	}
+}
+
+func TestClassifyRootCauseTemplateNoise(t *testing.T) {
+	event := baseTestEvent("post_tool_use")
+	event.Text.AssistantSummary = "Root Cause: TBD\nFix: TBD\nEvidence: TBD"
+
+	got := ClassifyEvent(event)
+
+	if got.ShouldSave {
+		t.Fatal("template root cause text should not be save-eligible")
+	}
+	if got.Signal != "low" {
+		t.Fatalf("signal=%q, want low", got.Signal)
+	}
+}
+
+func TestClassifyConcreteRootCauseAsReviewCandidate(t *testing.T) {
+	event := baseTestEvent("post_tool_use")
+	event.Text.AssistantSummary = "Root cause: cmd/sync.go:88 returned text even when --format json. Fixed by routing status through OutputJSON. Verified with go test ./cmd."
+
+	got := ClassifyEvent(event)
+
+	if got.ShouldSave {
+		t.Fatal("root cause candidates should require review in the first deterministic pass")
+	}
+	if got.Signal != "medium" {
+		t.Fatalf("signal=%q, want medium", got.Signal)
+	}
+}
+
+func TestRedactSensitiveText(t *testing.T) {
+	event := baseTestEvent("user_prompt_submit")
+	event.Text.UserPrompt = "Please remember token=secret-value and Authorization: Bearer abc123def456"
+
+	got := ClassifyEvent(event)
+
+	if got.ProposedNote == nil {
+		t.Fatal("expected proposed note")
+	}
+	if got.ProposedNote.Title == event.Text.UserPrompt {
+		t.Fatal("expected redacted title")
+	}
+	if len(got.Warnings) == 0 || got.Warnings[0] != "redacted_sensitive_text" {
+		t.Fatalf("warnings=%#v, want redaction warning", got.Warnings)
+	}
+}
+
+func baseTestEvent(eventType string) HookEvent {
+	return HookEvent{
+		SchemaVersion: SchemaVersion,
+		Agent: AgentInfo{
+			Name:    "codex",
+			Version: "test",
+			Surface: "cli",
+		},
+		Event: EventInfo{Type: eventType},
+	}
+}
+
+func containsTag(tags []string, want string) bool {
+	for _, tag := range tags {
+		if tag == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/hooks/eval.go
+++ b/pkg/hooks/eval.go
@@ -1,0 +1,161 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type EvalCase struct {
+	Name     string           `json:"name"`
+	Event    HookEvent        `json:"event"`
+	Expected ExpectedDecision `json:"expected"`
+}
+
+type ExpectedDecision struct {
+	ShouldSave *bool  `json:"should_save,omitempty"`
+	Signal     string `json:"signal,omitempty"`
+	Category   string `json:"category,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+type EvalReport struct {
+	Total     int              `json:"total"`
+	Passed    int              `json:"passed"`
+	Failed    int              `json:"failed"`
+	TruePos   int              `json:"true_positive"`
+	FalsePos  int              `json:"false_positive"`
+	TrueNeg   int              `json:"true_negative"`
+	FalseNeg  int              `json:"false_negative"`
+	Precision float64          `json:"precision"`
+	Recall    float64          `json:"recall"`
+	F1        float64          `json:"f1"`
+	Cases     []EvalCaseResult `json:"cases"`
+}
+
+type EvalCaseResult struct {
+	Name     string           `json:"name"`
+	Pass     bool             `json:"pass"`
+	Expected ExpectedDecision `json:"expected"`
+	Actual   Decision         `json:"actual"`
+	Errors   []string         `json:"errors,omitempty"`
+}
+
+func RunEvalDir(dir string) (EvalReport, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return EvalReport{}, fmt.Errorf("read eval fixtures: %w", err)
+	}
+
+	paths := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, entry.Name()))
+	}
+	sort.Strings(paths)
+
+	if len(paths) == 0 {
+		return EvalReport{}, fmt.Errorf("no eval fixtures found in %s", dir)
+	}
+
+	report := EvalReport{}
+	for _, path := range paths {
+		result, err := runEvalCase(path)
+		if err != nil {
+			return EvalReport{}, err
+		}
+		report.Cases = append(report.Cases, result)
+		report.Total++
+		if result.Pass {
+			report.Passed++
+		} else {
+			report.Failed++
+		}
+
+		if result.Expected.ShouldSave != nil {
+			expectedPositive := *result.Expected.ShouldSave
+			actualPositive := result.Actual.ShouldSave
+			switch {
+			case expectedPositive && actualPositive:
+				report.TruePos++
+			case expectedPositive && !actualPositive:
+				report.FalseNeg++
+			case !expectedPositive && actualPositive:
+				report.FalsePos++
+			default:
+				report.TrueNeg++
+			}
+		}
+	}
+
+	report.Precision = ratio(report.TruePos, report.TruePos+report.FalsePos)
+	report.Recall = ratio(report.TruePos, report.TruePos+report.FalseNeg)
+	if report.Precision+report.Recall > 0 {
+		report.F1 = 2 * report.Precision * report.Recall / (report.Precision + report.Recall)
+	}
+
+	return report, nil
+}
+
+func runEvalCase(path string) (EvalCaseResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return EvalCaseResult{}, fmt.Errorf("read eval fixture %s: %w", path, err)
+	}
+
+	var evalCase EvalCase
+	if err := json.Unmarshal(data, &evalCase); err != nil {
+		return EvalCaseResult{}, fmt.Errorf("decode eval fixture %s: %w", path, err)
+	}
+	if evalCase.Name == "" {
+		evalCase.Name = strings.TrimSuffix(filepath.Base(path), ".json")
+	}
+	encodedEvent, err := json.Marshal(evalCase.Event)
+	if err != nil {
+		return EvalCaseResult{}, fmt.Errorf("encode eval event %s: %w", path, err)
+	}
+	if _, err := DecodeEventJSON(encodedEvent); err != nil {
+		return EvalCaseResult{}, fmt.Errorf("validate eval fixture %s: %w", path, err)
+	}
+
+	actual := ClassifyEvent(evalCase.Event)
+	result := EvalCaseResult{
+		Name:     evalCase.Name,
+		Expected: evalCase.Expected,
+		Actual:   actual,
+	}
+
+	if evalCase.Expected.ShouldSave != nil && actual.ShouldSave != *evalCase.Expected.ShouldSave {
+		result.Errors = append(result.Errors, fmt.Sprintf("should_save=%v want %v", actual.ShouldSave, *evalCase.Expected.ShouldSave))
+	}
+	if evalCase.Expected.Signal != "" && actual.Signal != evalCase.Expected.Signal {
+		result.Errors = append(result.Errors, fmt.Sprintf("signal=%q want %q", actual.Signal, evalCase.Expected.Signal))
+	}
+	if evalCase.Expected.Category != "" {
+		actualCategory := ""
+		if actual.ProposedNote != nil {
+			actualCategory = actual.ProposedNote.Category
+		}
+		if actualCategory != evalCase.Expected.Category {
+			result.Errors = append(result.Errors, fmt.Sprintf("category=%q want %q", actualCategory, evalCase.Expected.Category))
+		}
+	}
+	if evalCase.Expected.Reason != "" && actual.Reason != evalCase.Expected.Reason {
+		result.Errors = append(result.Errors, fmt.Sprintf("reason=%q want %q", actual.Reason, evalCase.Expected.Reason))
+	}
+
+	result.Pass = len(result.Errors) == 0
+	return result, nil
+}
+
+func ratio(numerator, denominator int) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return float64(numerator) / float64(denominator)
+}

--- a/pkg/hooks/eval_test.go
+++ b/pkg/hooks/eval_test.go
@@ -1,0 +1,23 @@
+package hooks
+
+import "testing"
+
+func TestRunEvalDir(t *testing.T) {
+	report, err := RunEvalDir("testdata/eval")
+	if err != nil {
+		t.Fatalf("RunEvalDir: %v", err)
+	}
+
+	if report.Total < 4 {
+		t.Fatalf("total=%d, want at least 4", report.Total)
+	}
+	if report.Failed != 0 {
+		t.Fatalf("failed=%d, cases=%#v", report.Failed, report.Cases)
+	}
+	if report.FalsePos != 0 {
+		t.Fatalf("false positives=%d", report.FalsePos)
+	}
+	if report.FalseNeg != 0 {
+		t.Fatalf("false negatives=%d", report.FalseNeg)
+	}
+}

--- a/pkg/hooks/event.go
+++ b/pkg/hooks/event.go
@@ -1,0 +1,110 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+const SchemaVersion = "claudemem.hook_event.v1"
+
+type HookEvent struct {
+	SchemaVersion string          `json:"schema_version"`
+	Agent         AgentInfo       `json:"agent"`
+	Event         EventInfo       `json:"event"`
+	Session       SessionInfo     `json:"session,omitempty"`
+	Tool          ToolInfo        `json:"tool,omitempty"`
+	Text          TextInfo        `json:"text,omitempty"`
+	Limits        Limits          `json:"limits,omitempty"`
+	Raw           json.RawMessage `json:"raw,omitempty"`
+}
+
+type AgentInfo struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
+	Surface string `json:"surface,omitempty"`
+}
+
+type EventInfo struct {
+	Type       string `json:"type"`
+	NativeType string `json:"native_type,omitempty"`
+	Timestamp  string `json:"timestamp,omitempty"`
+}
+
+type SessionInfo struct {
+	ID      string `json:"id,omitempty"`
+	CWD     string `json:"cwd,omitempty"`
+	Project string `json:"project,omitempty"`
+	Branch  string `json:"branch,omitempty"`
+}
+
+type ToolInfo struct {
+	Name          string `json:"name,omitempty"`
+	InputSummary  string `json:"input_summary,omitempty"`
+	OutputSummary string `json:"output_summary,omitempty"`
+	ExitCode      *int   `json:"exit_code,omitempty"`
+}
+
+type TextInfo struct {
+	UserPrompt       string `json:"user_prompt,omitempty"`
+	AssistantSummary string `json:"assistant_summary,omitempty"`
+}
+
+type Limits struct {
+	MaxPayloadBytes int  `json:"max_payload_bytes,omitempty"`
+	AllowNetwork    bool `json:"allow_network,omitempty"`
+}
+
+type Decision struct {
+	Action       string        `json:"action"`
+	ShouldSave   bool          `json:"should_save"`
+	Signal       string        `json:"signal"`
+	Reason       string        `json:"reason"`
+	ProposedNote *ProposedNote `json:"proposed_note"`
+	Warnings     []string      `json:"warnings,omitempty"`
+}
+
+type ProposedNote struct {
+	Category          string   `json:"category"`
+	Title             string   `json:"title"`
+	ActionableSummary string   `json:"actionable_summary"`
+	Tags              []string `json:"tags"`
+}
+
+func EvaluateEventJSON(data []byte) (Decision, error) {
+	event, err := DecodeEventJSON(data)
+	if err != nil {
+		return Decision{}, err
+	}
+	return ClassifyEvent(event), nil
+}
+
+func DecodeEventJSON(data []byte) (HookEvent, error) {
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return HookEvent{}, fmt.Errorf("empty hook payload")
+	}
+
+	var event HookEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		return HookEvent{}, fmt.Errorf("decode hook payload: %w", err)
+	}
+
+	if strings.TrimSpace(event.SchemaVersion) != SchemaVersion {
+		return HookEvent{}, fmt.Errorf("unsupported hook schema_version %q", event.SchemaVersion)
+	}
+	if strings.TrimSpace(event.Event.Type) == "" {
+		return HookEvent{}, fmt.Errorf("hook event.type is required")
+	}
+
+	return event, nil
+}
+
+func NewSkipDecision(reason string) Decision {
+	return Decision{
+		Action:       "candidate",
+		ShouldSave:   false,
+		Signal:       "low",
+		Reason:       reason,
+		ProposedNote: nil,
+	}
+}

--- a/pkg/hooks/testdata/eval/explicit_memory.json
+++ b/pkg/hooks/testdata/eval/explicit_memory.json
@@ -1,0 +1,23 @@
+{
+  "name": "explicit memory request",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "cli"
+    },
+    "event": {
+      "type": "user_prompt_submit",
+      "native_type": "UserPromptSubmit"
+    },
+    "text": {
+      "user_prompt": "Please remember this: Claude Code and Codex are P0 adapters for claudemem."
+    }
+  },
+  "expected": {
+    "should_save": true,
+    "signal": "high",
+    "category": "user-requirement"
+  }
+}

--- a/pkg/hooks/testdata/eval/negative_memory_request.json
+++ b/pkg/hooks/testdata/eval/negative_memory_request.json
@@ -1,0 +1,22 @@
+{
+  "name": "negative memory request",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "cli"
+    },
+    "event": {
+      "type": "user_prompt_submit",
+      "native_type": "UserPromptSubmit"
+    },
+    "text": {
+      "user_prompt": "Do not remember this temporary workaround."
+    }
+  },
+  "expected": {
+    "should_save": false,
+    "signal": "low"
+  }
+}

--- a/pkg/hooks/testdata/eval/release_fact.json
+++ b/pkg/hooks/testdata/eval/release_fact.json
@@ -1,0 +1,27 @@
+{
+  "name": "verified release fact",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "desktop"
+    },
+    "event": {
+      "type": "post_tool_use",
+      "native_type": "PostToolUse"
+    },
+    "session": {
+      "project": "claudemem"
+    },
+    "tool": {
+      "name": "gh",
+      "output_summary": "Release v3.0.11 published successfully and PR checks passed."
+    }
+  },
+  "expected": {
+    "should_save": true,
+    "signal": "high",
+    "category": "project"
+  }
+}

--- a/pkg/hooks/testdata/eval/release_test_noise.json
+++ b/pkg/hooks/testdata/eval/release_test_noise.json
@@ -1,0 +1,23 @@
+{
+  "name": "release test output noise",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "cli"
+    },
+    "event": {
+      "type": "post_tool_use",
+      "native_type": "PostToolUse"
+    },
+    "tool": {
+      "name": "Bash",
+      "output_summary": "Release tests for v3.0.11 passed."
+    }
+  },
+  "expected": {
+    "should_save": false,
+    "signal": "low"
+  }
+}

--- a/pkg/hooks/testdata/eval/root_cause_review.json
+++ b/pkg/hooks/testdata/eval/root_cause_review.json
@@ -1,0 +1,22 @@
+{
+  "name": "root cause review candidate",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "cli"
+    },
+    "event": {
+      "type": "post_tool_use",
+      "native_type": "PostToolUse"
+    },
+    "text": {
+      "assistant_summary": "Root cause: cmd/sync.go:88 returned text even when --format json. Fixed by routing status through OutputJSON. Verified with go test ./cmd."
+    }
+  },
+  "expected": {
+    "should_save": false,
+    "signal": "medium"
+  }
+}

--- a/pkg/hooks/testdata/eval/root_cause_template_noise.json
+++ b/pkg/hooks/testdata/eval/root_cause_template_noise.json
@@ -1,0 +1,22 @@
+{
+  "name": "root cause template noise",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "cli"
+    },
+    "event": {
+      "type": "post_tool_use",
+      "native_type": "PostToolUse"
+    },
+    "text": {
+      "assistant_summary": "Root Cause: TBD\nFix: TBD\nEvidence: TBD"
+    }
+  },
+  "expected": {
+    "should_save": false,
+    "signal": "low"
+  }
+}

--- a/pkg/hooks/testdata/eval/transient_test_output.json
+++ b/pkg/hooks/testdata/eval/transient_test_output.json
@@ -1,0 +1,23 @@
+{
+  "name": "transient test output",
+  "event": {
+    "schema_version": "claudemem.hook_event.v1",
+    "agent": {
+      "name": "codex",
+      "version": "test",
+      "surface": "cli"
+    },
+    "event": {
+      "type": "post_tool_use",
+      "native_type": "PostToolUse"
+    },
+    "tool": {
+      "name": "Bash",
+      "output_summary": "ok github.com/zelinewang/claudemem/pkg/hooks 0.012s\nPASS"
+    }
+  },
+  "expected": {
+    "should_save": false,
+    "signal": "low"
+  }
+}


### PR DESCRIPTION
## Summary
- add `claudemem hook event --dry-run --payload -` for normalized, non-mutating hook decisions
- add an agent-neutral deterministic classifier with redaction and template-based proposed notes
- add `claudemem hook eval` plus golden fixtures for precision/recall tracking before autosave
- update universal integration docs with eval, dedupe, and bounded queue quality gates
- clean public-sweep path examples in existing docs/help text

## Verification
- `make test-all`
- `go run . hook eval --format json` -> 7/7 fixtures, precision 1.00, recall 1.00, F1 1.00
- `go run . hook event --dry-run --payload -` smoke-tested explicit memory and release-test noise payloads
- `~/.claude/scripts/pre-public-sweep.sh /Users/zane/claudemem` -> 0 Layer 1-4 blockers; remaining warnings are license/changelog/contributing/public metadata only

## Notes
This PR intentionally does not persist candidates or enable autosave. Root-cause and config-gotcha detections remain review-only medium-signal candidates until backtested against existing memories.