### PR TITLE
Add Vertex AI embedding backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,19 @@
 module github.com/zelinewang/claudemem
 
-go 1.24.12
+go 1.25.0
 
 toolchain go1.25.9
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/oauth2 v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.46.1
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
@@ -25,6 +27,8 @@ golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546/go.mod h1:j/pmGrbnkbPtQfxEe5D0VQhZC6qKbfKifgD0oM7sR70=
 golang.org/x/mod v0.32.0 h1:9F4d3PHLljb6x//jOyokMv3eX+YDeepZSEo3mFJy93c=
 golang.org/x/mod v0.32.0/go.mod h1:SgipZ/3h2Ci89DlEtEXWUk/HteuRin+HHhN+WbNhguU=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/storage/filestore_vectors.go
+++ b/pkg/storage/filestore_vectors.go
@@ -18,6 +18,8 @@ import (
 //	embedding.dimensions    (matryoshka truncation; 0 = native)
 //	embedding.endpoint      (optional URL override, e.g., Ollama on a remote host)
 //	embedding.api_key_env   (name of the env var holding the API key for cloud)
+//	embedding.project       (Vertex AI project ID; falls back to GOOGLE_CLOUD_PROJECT)
+//	embedding.location      (Vertex AI region; falls back to GOOGLE_CLOUD_LOCATION)
 //
 // For P1 this only supports Ollama and TF-IDF; Gemini/Voyage/OpenAI land in
 // later phases. The backend is constructed but NOT pinged here — availability
@@ -62,11 +64,22 @@ func loadBackendConfig(storeDir string) (vectors.BackendConfig, error) {
 		Model:    cfg.GetString("embedding.model"),
 		Endpoint: cfg.GetString("embedding.endpoint"),
 		Dim:      cfg.GetInt("embedding.dimensions"),
+		Project:  firstNonEmpty(cfg.GetString("embedding.project"), os.Getenv("GOOGLE_CLOUD_PROJECT"), os.Getenv("GEMINI_VERTEX_PROJECT")),
+		Location: firstNonEmpty(cfg.GetString("embedding.location"), os.Getenv("GOOGLE_CLOUD_LOCATION"), os.Getenv("GEMINI_VERTEX_LOCATION")),
 	}
 	if keyEnv := cfg.GetString("embedding.api_key_env"); keyEnv != "" {
 		bc.APIKey = os.Getenv(keyEnv)
 	}
 	return bc, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // HasVectorStore returns true if semantic search is initialized.

--- a/pkg/vectors/registry.go
+++ b/pkg/vectors/registry.go
@@ -9,11 +9,13 @@ import (
 // for building an Embedder. Populated by the setup wizard (P3) or by
 // reading flat config keys (embedding.backend, embedding.model, ...).
 type BackendConfig struct {
-	Backend  string // "ollama" | "gemini" | "voyage" | "openai" | "tfidf"
+	Backend  string // "ollama" | "gemini" | "vertex" | "voyage" | "openai" | "tfidf"
 	Model    string
 	Endpoint string // optional URL override
 	APIKey   string // plaintext; obtained by the caller from os.Getenv
 	Dim      int    // optional matryoshka truncation target (0 = native)
+	Project  string // Vertex AI project ID
+	Location string // Vertex AI region, e.g. "us-central1"
 }
 
 // BuildEmbedder materialises an Embedder from a BackendConfig.
@@ -45,6 +47,17 @@ func BuildEmbedder(cfg BackendConfig) (Embedder, error) {
 			emb.WithBaseURL(cfg.Endpoint)
 		}
 		return emb, nil
+
+	case "vertex", "vertexai", "vertex-ai":
+		model := cfg.Model
+		if model == "" {
+			model = "gemini-embedding-001"
+		}
+		emb := NewVertexEmbedder(cfg.Project, cfg.Location, model, cfg.Dim)
+		if cfg.Endpoint != "" {
+			emb.WithBaseURL(cfg.Endpoint)
+		}
+		return emb, nil
 	case "voyage":
 		model := cfg.Model
 		if model == "" {
@@ -68,6 +81,6 @@ func BuildEmbedder(cfg BackendConfig) (Embedder, error) {
 		return emb, nil
 
 	default:
-		return nil, fmt.Errorf("unknown embedding backend %q (known: tfidf, ollama, gemini, voyage, openai)", cfg.Backend)
+		return nil, fmt.Errorf("unknown embedding backend %q (known: tfidf, ollama, gemini, vertex, voyage, openai)", cfg.Backend)
 	}
 }

--- a/pkg/vectors/vertex.go
+++ b/pkg/vectors/vertex.go
@@ -1,0 +1,252 @@
+package vectors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+const (
+	defaultVertexLocation = "us-central1"
+	vertexCloudScope      = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+// VertexEmbedder uses Vertex AI publisher models with Application Default
+// Credentials. This is the service-account path for Gemini embeddings; it
+// does not use Google AI Studio API keys.
+type VertexEmbedder struct {
+	project     string
+	location    string
+	model       string
+	dim         int
+	baseURL     string
+	client      *http.Client
+	tokenSource oauth2.TokenSource
+	tokenMu     sync.Mutex
+}
+
+func NewVertexEmbedder(project, location, model string, dim int) *VertexEmbedder {
+	if location == "" {
+		location = defaultVertexLocation
+	}
+	if model == "" {
+		model = "gemini-embedding-001"
+	}
+	return &VertexEmbedder{
+		project:  project,
+		location: location,
+		model:    model,
+		dim:      dim,
+		baseURL:  "https://" + location + "-aiplatform.googleapis.com/v1",
+		client:   &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+func (v *VertexEmbedder) WithBaseURL(u string) *VertexEmbedder {
+	v.baseURL = strings.TrimRight(u, "/")
+	return v
+}
+
+func (v *VertexEmbedder) WithTokenSource(ts oauth2.TokenSource) *VertexEmbedder {
+	v.tokenSource = ts
+	return v
+}
+
+func (v *VertexEmbedder) Name() string { return "vertex" }
+
+func (v *VertexEmbedder) Model() string { return v.model }
+
+func (v *VertexEmbedder) Dimensions() int {
+	if v.dim > 0 {
+		return v.dim
+	}
+	return 3072
+}
+
+func (v *VertexEmbedder) Available() error {
+	_, err := v.Embed("claudemem vertex embedding health check", InputTypeDocument)
+	return err
+}
+
+func (v *VertexEmbedder) Embed(text string, t InputType) ([]float32, error) {
+	vecs, err := v.EmbedBatch([]string{text}, t)
+	if err != nil {
+		return nil, err
+	}
+	if len(vecs) == 0 || len(vecs[0]) == 0 {
+		return nil, fmt.Errorf("vertex returned empty embedding")
+	}
+	return vecs[0], nil
+}
+
+func (v *VertexEmbedder) EmbedBatch(texts []string, t InputType) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	if err := v.validateConfig(); err != nil {
+		return nil, err
+	}
+
+	instances := make([]vertexEmbeddingInstance, len(texts))
+	for i, text := range texts {
+		instances[i] = vertexEmbeddingInstance{
+			Content:  text,
+			TaskType: vertexTaskType(t),
+		}
+	}
+	body := vertexPredictRequest{
+		Instances: instances,
+		Parameters: vertexEmbeddingParameters{
+			OutputDimensionality: v.dim,
+		},
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal vertex request: %w", err)
+	}
+
+	resp, err := v.postPredict(raw)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, &ErrBackendUnavailable{
+			Backend: v.Name() + ":" + v.model,
+			Cause:   fmt.Errorf("auth rejected (HTTP %d): %s", resp.StatusCode, string(b)),
+			Hint:    "verify GOOGLE_APPLICATION_CREDENTIALS points to a Vertex-enabled service account and GOOGLE_CLOUD_PROJECT/GOOGLE_CLOUD_LOCATION are correct",
+		}
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("vertex predict HTTP %d: %s", resp.StatusCode, string(b))
+	}
+
+	var parsed vertexPredictResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("decode vertex response: %w", err)
+	}
+	if len(parsed.Predictions) != len(texts) {
+		return nil, fmt.Errorf("expected %d embeddings, got %d", len(texts), len(parsed.Predictions))
+	}
+	out := make([][]float32, len(parsed.Predictions))
+	for i, prediction := range parsed.Predictions {
+		if len(prediction.Embeddings.Values) == 0 {
+			return nil, fmt.Errorf("vertex returned empty embedding at index %d", i)
+		}
+		out[i] = prediction.Embeddings.Values
+	}
+	return out, nil
+}
+
+func (v *VertexEmbedder) validateConfig() error {
+	if v.project == "" {
+		return &ErrBackendUnavailable{
+			Backend: v.Name() + ":" + v.model,
+			Cause:   fmt.Errorf("no Vertex AI project configured"),
+			Hint:    "set embedding.project or export GOOGLE_CLOUD_PROJECT",
+		}
+	}
+	if v.location == "" {
+		return &ErrBackendUnavailable{
+			Backend: v.Name() + ":" + v.model,
+			Cause:   fmt.Errorf("no Vertex AI location configured"),
+			Hint:    "set embedding.location or export GOOGLE_CLOUD_LOCATION",
+		}
+	}
+	return nil
+}
+
+func (v *VertexEmbedder) postPredict(body []byte) (*http.Response, error) {
+	token, err := v.token()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest("POST", v.predictURL(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+	return v.client.Do(req)
+}
+
+func (v *VertexEmbedder) token() (*oauth2.Token, error) {
+	v.tokenMu.Lock()
+	defer v.tokenMu.Unlock()
+
+	if v.tokenSource == nil {
+		creds, err := google.FindDefaultCredentials(context.Background(), vertexCloudScope)
+		if err != nil {
+			return nil, &ErrBackendUnavailable{
+				Backend: v.Name() + ":" + v.model,
+				Cause:   err,
+				Hint:    "export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json",
+			}
+		}
+		if v.project == "" && creds.ProjectID != "" {
+			v.project = creds.ProjectID
+		}
+		v.tokenSource = creds.TokenSource
+	}
+	token, err := v.tokenSource.Token()
+	if err != nil {
+		return nil, &ErrBackendUnavailable{
+			Backend: v.Name() + ":" + v.model,
+			Cause:   err,
+			Hint:    "verify the service-account JSON in GOOGLE_APPLICATION_CREDENTIALS is valid",
+		}
+	}
+	return token, nil
+}
+
+func (v *VertexEmbedder) predictURL() string {
+	return v.baseURL + "/projects/" + url.PathEscape(v.project) +
+		"/locations/" + url.PathEscape(v.location) +
+		"/publishers/google/models/" + url.PathEscape(v.model) + ":predict"
+}
+
+func vertexTaskType(t InputType) string {
+	switch t {
+	case InputTypeQuery:
+		return "RETRIEVAL_QUERY"
+	case InputTypeDocument:
+		return "RETRIEVAL_DOCUMENT"
+	default:
+		return "RETRIEVAL_DOCUMENT"
+	}
+}
+
+type vertexPredictRequest struct {
+	Instances  []vertexEmbeddingInstance `json:"instances"`
+	Parameters vertexEmbeddingParameters `json:"parameters,omitempty"`
+}
+
+type vertexEmbeddingInstance struct {
+	Content  string `json:"content"`
+	TaskType string `json:"task_type,omitempty"`
+}
+
+type vertexEmbeddingParameters struct {
+	OutputDimensionality int `json:"outputDimensionality,omitempty"`
+}
+
+type vertexPredictResponse struct {
+	Predictions []vertexPrediction `json:"predictions"`
+}
+
+type vertexPrediction struct {
+	Embeddings geminiEmbeddingValues `json:"embeddings"`
+}

--- a/pkg/vectors/vertex_test.go
+++ b/pkg/vectors/vertex_test.go
@@ -1,0 +1,151 @@
+package vectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func newVertexMockServer(t *testing.T, handler func(path string, body []byte) (int, string)) (*httptest.Server, *VertexEmbedder) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("request to %s missing bearer token, got %q", r.URL.Path, r.Header.Get("Authorization"))
+			http.Error(w, "no token", http.StatusUnauthorized)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		status, resp := handler(r.URL.Path, body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		w.Write([]byte(resp))
+	}))
+	emb := NewVertexEmbedder("test-project", "us-central1", "gemini-embedding-001", 768).
+		WithBaseURL(srv.URL).
+		WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "test-token"}))
+	return srv, emb
+}
+
+func TestVertex_Embed_BuildsPredictRequest(t *testing.T) {
+	var seenPath, seenBody string
+	srv, emb := newVertexMockServer(t, func(path string, body []byte) (int, string) {
+		seenPath = path
+		seenBody = string(body)
+		return 200, `{"predictions":[{"embeddings":{"values":[0.1,0.2,0.3]}}]}`
+	})
+	defer srv.Close()
+
+	vec, err := emb.Embed("what is vertex?", InputTypeDocument)
+	if err != nil {
+		t.Fatalf("Embed failed: %v", err)
+	}
+	if len(vec) != 3 || vec[0] != 0.1 || vec[1] != 0.2 || vec[2] != 0.3 {
+		t.Errorf("unexpected vector: %v", vec)
+	}
+	if !strings.HasSuffix(seenPath, "/projects/test-project/locations/us-central1/publishers/google/models/gemini-embedding-001:predict") {
+		t.Errorf("wrong path: %s", seenPath)
+	}
+	var req map[string]interface{}
+	if err := json.Unmarshal([]byte(seenBody), &req); err != nil {
+		t.Fatalf("could not parse sent body: %v", err)
+	}
+	instances, _ := req["instances"].([]interface{})
+	first, _ := instances[0].(map[string]interface{})
+	if first["content"] != "what is vertex?" {
+		t.Errorf("wrong content: %v", first["content"])
+	}
+	if first["task_type"] != "RETRIEVAL_DOCUMENT" {
+		t.Errorf("expected task_type=RETRIEVAL_DOCUMENT, got %v", first["task_type"])
+	}
+	parameters, _ := req["parameters"].(map[string]interface{})
+	if dim, _ := parameters["outputDimensionality"].(float64); int(dim) != 768 {
+		t.Errorf("expected outputDimensionality=768, got %v", parameters["outputDimensionality"])
+	}
+}
+
+func TestVertex_EmbedBatch_QueryTaskType(t *testing.T) {
+	var seenBody string
+	srv, emb := newVertexMockServer(t, func(path string, body []byte) (int, string) {
+		seenBody = string(body)
+		return 200, `{"predictions":[{"embeddings":{"values":[1.0]}},{"embeddings":{"values":[2.0]}}]}`
+	})
+	defer srv.Close()
+
+	vecs, err := emb.EmbedBatch([]string{"one", "two"}, InputTypeQuery)
+	if err != nil {
+		t.Fatalf("EmbedBatch failed: %v", err)
+	}
+	if len(vecs) != 2 {
+		t.Fatalf("expected 2 vectors, got %d", len(vecs))
+	}
+	if strings.Count(seenBody, `"task_type":"RETRIEVAL_QUERY"`) != 2 {
+		t.Errorf("InputTypeQuery did not produce query task type for every instance, body: %s", seenBody)
+	}
+}
+
+func TestVertex_AuthRejectedIsBackendUnavailable(t *testing.T) {
+	srv, emb := newVertexMockServer(t, func(path string, body []byte) (int, string) {
+		return 403, `{"error":{"message":"permission denied"}}`
+	})
+	defer srv.Close()
+
+	_, err := emb.Embed("hello", InputTypeDocument)
+	if !IsBackendUnavailable(err) {
+		t.Fatalf("expected ErrBackendUnavailable, got %T: %v", err, err)
+	}
+	if strings.Contains(err.Error(), "aistudio.google.com") {
+		t.Fatalf("vertex auth error must not point users to AI Studio: %v", err)
+	}
+}
+
+func TestVertex_MissingProject(t *testing.T) {
+	emb := NewVertexEmbedder("", "us-central1", "gemini-embedding-001", 768)
+	_, err := emb.Embed("hello", InputTypeDocument)
+	if !IsBackendUnavailable(err) {
+		t.Fatalf("expected ErrBackendUnavailable, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "GOOGLE_CLOUD_PROJECT") {
+		t.Errorf("missing project hint should mention GOOGLE_CLOUD_PROJECT, got: %v", err)
+	}
+}
+
+func TestVertex_Registry_BuildsFromConfig(t *testing.T) {
+	cfg := BackendConfig{
+		Backend:  "vertex",
+		Model:    "gemini-embedding-001",
+		Dim:      768,
+		Project:  "test-project",
+		Location: "us-central1",
+	}
+	emb, err := BuildEmbedder(cfg)
+	if err != nil {
+		t.Fatalf("BuildEmbedder: %v", err)
+	}
+	if emb.Name() != "vertex" {
+		t.Errorf("expected vertex backend, got %s", emb.Name())
+	}
+	if emb.Dimensions() != 768 {
+		t.Errorf("expected 768 dims, got %d", emb.Dimensions())
+	}
+}
+
+func TestVertex_EmbedBatch_LengthMismatch(t *testing.T) {
+	srv, emb := newVertexMockServer(t, func(path string, body []byte) (int, string) {
+		return 200, `{"predictions":[{"embeddings":{"values":[1.0]}}]}`
+	})
+	defer srv.Close()
+
+	_, err := emb.EmbedBatch([]string{"one", "two"}, InputTypeDocument)
+	if err == nil {
+		t.Fatal("expected length mismatch error")
+	}
+	if !strings.Contains(fmt.Sprint(err), "expected 2 embeddings") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a Vertex AI embedding backend that authenticates via Application Default Credentials instead of Google AI Studio API keys.
- Wire `embedding.project` and `embedding.location` config into the embedding backend config.
- Add unit tests for Vertex predict request shape, bearer auth, query/document task types, registry wiring, and auth errors.

## Verification
- `go test ./...`
- Live local config smoke: `claudemem repair --yes` rebuilt 2241 documents using `vertex:gemini-embedding-001`.
- `claudemem note add` and `claudemem search` both worked with `embedding.backend=vertex`.
- Confirmed no Ollama binary or local Ollama listener remains on this machine.

## Notes
- No service-account JSON, API key, or local credential path is committed.
